### PR TITLE
headerボタンにリンク設定、スタイル調整、ブランド名変更

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -27,7 +27,7 @@ const routes: Routes = [
     canActivate: [AuthGuard]
   },
   {
-    path: 'mypage',
+    path: ':id',
     loadChildren: () =>
       import('./mypage/mypage.module').then((m) => m.MypageModule),
     canLoad: [AuthGuard],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,3 +1,5 @@
 <app-header></app-header>
-<router-outlet></router-outlet>
+<div class="container">
+  <router-outlet></router-outlet>
+</div>
 <app-footer></app-footer>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,9 +1,9 @@
 <footer class="footer">
   <div class="footer__nav">
-    <a routerlink="#" href="#">DTMPlaceについて</a>
-    <a routerlink="#" href="#">利用規約</a>
-    <a routerlink="#" href="#">特定商取引法に基づく表記</a>
-    <a routerlink="#" href="#">お問い合わせ</a>
+    <a routerLink="/about">DTMPlaceについて</a>
+    <a routerLink="/terms">利用規約</a>
+    <a routerLink="/legal">特定商取引法に基づく表記</a>
+    <a href="https://twitter.com/MusiL_DTM">お問い合わせ</a>
   </div>
   <p class="copyright">&copy; 2020 DTMPlace by komura</p>
 </footer>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -1,9 +1,9 @@
 <footer class="footer">
   <div class="footer__nav">
-    <a routerLink="/about">DTMPlaceについて</a>
+    <a routerLink="/about">MusiLについて</a>
     <a routerLink="/terms">利用規約</a>
     <a routerLink="/legal">特定商取引法に基づく表記</a>
     <a href="https://twitter.com/MusiL_DTM">お問い合わせ</a>
   </div>
-  <p class="copyright">&copy; 2020 DTMPlace by komura</p>
+  <p class="copyright">&copy; 2020 MusiL by komura</p>
 </footer>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar class="header">
   <mat-toolbar-row class="header__container">
-    <a routerLink="/" class="header__title">DTMPlace</a>
+    <a routerLink="/" class="header__title">MusiL</a>
     <form class="search">
       <input matInput placeholder="キーワードを入力" class="search__input" autocomplete="off" />
       <button mat-icon-button color="white" aria-label="検索アイコン" class="search__button">

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -16,7 +16,7 @@
 
     <ng-container *ngIf="user$ | async as user; else default">
       <div class="header__nav">
-        <button mat-flat-button color="primary" medium class="post-button">
+        <button mat-flat-button color="primary" medium class="post-button" routerLink="/notes/create">
           <mat-icon>post_add</mat-icon>
           <span>投稿する</span>
         </button>
@@ -27,15 +27,15 @@
 
 
         <mat-menu #menu="matMenu">
-          <button mat-menu-item>
+          <button mat-menu-item [routerLink]="['/', user.uid]">
             <mat-icon>account_box</mat-icon>
             <span>マイページ</span>
           </button>
-          <button mat-menu-item>
+          <button mat-menu-item mat-menu-item routerLink="/notes">
             <mat-icon>article</mat-icon>
             <span>記事一覧</span>
           </button>
-          <button (click)="logout()" mat-menu-item color="primary" medium class="logout-button">
+          <button (click)="logout()" mat-menu-item class="logout-button">
             <mat-icon>exit_to_app</mat-icon>
             <span>ログアウト</span>
           </button>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -27,7 +27,7 @@
 
 
         <mat-menu #menu="matMenu">
-          <button mat-menu-item [routerLink]="['/', user.uid]">
+          <button mat-menu-item [routerLink]="['/', user.providerData[0].uid]">
             <mat-icon>account_box</mat-icon>
             <span>マイページ</span>
           </button>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -15,8 +15,9 @@
   &__title {
     color: #ffffff;
     font-weight: bold;
-    font-size: 24px;
+    font-size: 28px;
     text-decoration: none;
+    letter-spacing: 2px;
   }
   &__nav {
     display: flex;

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -1,16 +1,14 @@
-<div class="container">
-  <div class="home-page">
-    <div class="home-main">
-      <h3 class="home-main__title">トレンド</h3>
-      <ng-container *ngFor="let article of articles$ | async">
-        <app-article *ngIf="article" [article]="article"></app-article>
-      </ng-container>
-    </div>
-    <div class="home-sub">
-      <h3 class="home-main__title">最新の記事</h3>
-      <ng-container *ngFor="let article of articles$ | async">
-        <app-article *ngIf="article" [article]="article"></app-article>
-      </ng-container>
-    </div>
+<div class="home-page">
+  <div class="home-main">
+    <h3 class="home-main__title">トレンド</h3>
+    <ng-container *ngFor="let article of articles$ | async">
+      <app-article *ngIf="article" [article]="article"></app-article>
+    </ng-container>
+  </div>
+  <div class="home-sub">
+    <h3 class="home-main__title">最新の記事</h3>
+    <ng-container *ngFor="let article of articles$ | async">
+      <app-article *ngIf="article" [article]="article"></app-article>
+    </ng-container>
   </div>
 </div>

--- a/src/app/mypage/note/note.component.html
+++ b/src/app/mypage/note/note.component.html
@@ -1,62 +1,60 @@
-<div class="container">
-  <div class="note">
-    <div class="note-header">
-      <div class="note-header__author">
-        <a href="#">
-          <img src='https://placehold.it/40x40' alt='ユーザーアイコン' class="note-header__user-icon" />
-        </a>
-        <a href="#" class="note-header__user-name">
+<div class="note">
+  <div class="note-header">
+    <div class="note-header__author">
+      <a href="#">
+        <img src='https://placehold.it/40x40' alt='ユーザーアイコン' class="note-header__user-icon" />
+      </a>
+      <a href="#" class="note-header__user-name">
+        こむら
+      </a>
+      <a class="note-header__twitter">
+        <img src="/assets/icons/twitter.png" alt="twitterアイコン">
+      </a>
+      <p class="note-header__updated-date">2020年10月10日に更新</p>
+    </div>
+    <h1 class="note-header__title">Logic Pro Xの大型アップデートの変更内容
+    </h1>
+    <a href="#" class="note-header__tag">DTM</a>
+    <a href="#" class="note-header__tag">Sylenth1</a>
+  </div>
+  <div class="note__content">
+    <h2>はじめに</h2>
+    <p>今回のLogicProのアップデートではEXS24がSamplerになりました</p>
+    <h2>Samplerの変更点</h2>
+    <p>以前よりもサンプルを加工しやすくなった。パラメーターが以下の通り増えている。</p>
+    <br>
+    <p>実際に</p>
+    <img src='https://placehold.it/800x200' alt='イメージ1' />
+    <p>ということだ</p>
+  </div>
+  <div class="note-footer">
+    <div class="actions">
+      <button mat-icon-button color="warn" class="actions__favorite" aria-label="いいね" matTooltip="いいね">
+        <mat-icon>favorite</mat-icon>
+      </button>
+      <div class="actions__share">
+        <button mat-icon-button class="actions__twitter" aria-label="Twitterでシェア" matTooltip="Twitterでシェア">
+          <img src="/assets/icons/twitter.png" alt="twitterアイコン">
+        </button>
+        <button mat-icon-button href="#" class="actions__link" aria-label="リンクをコピー" matTooltip="リンクをコピー">
+          <mat-icon>link</mat-icon>
+        </button>
+      </div>
+    </div>
+    <div class="note-footer__author">
+      <a href="#">
+        <img src='https://placehold.it/40x40' alt='ユーザーアイコン' class="note-footer__user-icon" />
+      </a>
+      <div class="note-footer__user-profile">
+        <a class="note-footer__user-name">
           こむら
         </a>
-        <a class="note-header__twitter">
-          <img src="/assets/icons/twitter.png" alt="twitterアイコン">
+        <p class="note-footer__user-text">インターネットと音楽が好きです</p>
+        <p>SNSでコメントを送ろう
+        </p>
+        <a>
+          <img class="note-footer__twitter" src="/assets/icons/twitter.png" alt="twitterアイコン">
         </a>
-        <p class="note-header__updated-date">2020年10月10日に更新</p>
-      </div>
-      <h1 class="note-header__title">Logic Pro Xの大型アップデートの変更内容
-      </h1>
-      <a href="#" class="note-header__tag">DTM</a>
-      <a href="#" class="note-header__tag">Sylenth1</a>
-    </div>
-    <div class="note__content">
-      <h2>はじめに</h2>
-      <p>今回のLogicProのアップデートではEXS24がSamplerになりました</p>
-      <h2>Samplerの変更点</h2>
-      <p>以前よりもサンプルを加工しやすくなった。パラメーターが以下の通り増えている。</p>
-      <br>
-      <p>実際に</p>
-      <img src='https://placehold.it/800x200' alt='イメージ1' />
-      <p>ということだ</p>
-    </div>
-    <div class="note-footer">
-      <div class="actions">
-        <button mat-icon-button color="warn" class="actions__favorite" aria-label="いいね" matTooltip="いいね">
-          <mat-icon>favorite</mat-icon>
-        </button>
-        <div class="actions__share">
-          <button mat-icon-button class="actions__twitter" aria-label="Twitterでシェア" matTooltip="Twitterでシェア">
-            <img src="/assets/icons/twitter.png" alt="twitterアイコン">
-          </button>
-          <button mat-icon-button href="#" class="actions__link" aria-label="リンクをコピー" matTooltip="リンクをコピー">
-            <mat-icon>link</mat-icon>
-          </button>
-        </div>
-      </div>
-      <div class="note-footer__author">
-        <a href="#">
-          <img src='https://placehold.it/40x40' alt='ユーザーアイコン' class="note-footer__user-icon" />
-        </a>
-        <div class="note-footer__user-profile">
-          <a class="note-footer__user-name">
-            こむら
-          </a>
-          <p class="note-footer__user-text">インターネットと音楽が好きです</p>
-          <p>SNSでコメントを送ろう
-          </p>
-          <a>
-            <img class="note-footer__twitter" src="/assets/icons/twitter.png" alt="twitterアイコン">
-          </a>
-        </div>
       </div>
     </div>
   </div>

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -1,29 +1,27 @@
-<div class="container">
-  <mat-card class="editor">
-    <form class="editor__form" [formGroup]="form">
-      <mat-form-field class="editor__title" floatLabel="always">
-        <mat-label></mat-label>
-        <input type="text" formControlName="title" matInput placeholder="タイトル（80文字以内）*" autocomplete="off" />
-        <mat-error *ngIf="titleControl.hasError('required')">必須入力です</mat-error>
-        <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは80文字以内にしてください</mat-error>
-      </mat-form-field>
-      <mat-form-field class="editor__tag" floatLabel="always">
-        <mat-label></mat-label>
-        <input type="text" formControlName="tag" matInput placeholder="作曲やDTMに関するタグを入力" autocomplete="off" />
-      </mat-form-field>
-      <div class="editor__body">
-        <angular-editor formControlName="editorContent" class="editor__content" [config]="editorConfig">
-        </angular-editor>
-        <div class="editor__preview" [innerHTML]='editorPreview'></div>
-      </div>
-      <div class="editor__buttons">
-        <button [disabled]="form.invalid" class="draft" mat-flat-button color="primary">
-          下書きに保存
-        </button>
-        <button [disabled]="form.invalid" class="post" mat-flat-button color="primary" (click)="submit()">
-          記事を公開する
-        </button>
-      </div>
-    </form>
-  </mat-card>
-</div>
+<mat-card class="editor">
+  <form class="editor__form" [formGroup]="form">
+    <mat-form-field class="editor__title" floatLabel="always">
+      <mat-label></mat-label>
+      <input type="text" formControlName="title" matInput placeholder="タイトル（80文字以内）*" autocomplete="off" />
+      <mat-error *ngIf="titleControl.hasError('required')">必須入力です</mat-error>
+      <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは80文字以内にしてください</mat-error>
+    </mat-form-field>
+    <mat-form-field class="editor__tag" floatLabel="always">
+      <mat-label></mat-label>
+      <input type="text" formControlName="tag" matInput placeholder="作曲やDTMに関するタグを入力" autocomplete="off" />
+    </mat-form-field>
+    <div class="editor__body">
+      <angular-editor formControlName="editorContent" class="editor__content" [config]="editorConfig">
+      </angular-editor>
+      <div class="editor__preview" [innerHTML]='editorPreview'></div>
+    </div>
+    <div class="editor__buttons">
+      <button [disabled]="form.invalid" class="draft" mat-flat-button color="primary">
+        下書きに保存
+      </button>
+      <button [disabled]="form.invalid" class="post" mat-flat-button color="primary" (click)="submit()">
+        記事を公開する
+      </button>
+    </div>
+  </form>
+</mat-card>

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -1,7 +1,5 @@
-.container {
-  padding: 60px 0 0 0;
-}
 .editor {
+  margin: -26px -16px -16px -16px;
   background-color: #ffffff;
   &__form {
     display: flex;

--- a/src/index.html
+++ b/src/index.html
@@ -1,15 +1,18 @@
 <!doctype html>
-<html lang="en">
+<html lang="jp">
+
 <head>
   <meta charset="utf-8">
-  <title>Dtmplace</title>
+  <title>MusiL</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
+
 <body>
   <app-root></app-root>
 </body>
+
 </html>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,7 +17,7 @@ img {
   max-width: 100%;
 }
 .container {
-  padding: 86px 16px 16px 16px;
+  padding: 76px 16px 16px 16px;
   background-color: #f5f5f5;
 }
 


### PR DESCRIPTION
fix #65 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ

![link mov](https://user-images.githubusercontent.com/37304826/85384738-67301d00-b57c-11ea-8cb1-8ab9114ee7e5.gif)

## 作業概要

- header内のリンク設定
- containerクラスをapp内に書くように変更
- mypageModuleを:idでのルーティングに変更
- mypageボタンのリンク先をtwitterのuidに変更
- ブランド名変更