### PR TITLE
ログインユーザー情報をFirestoreに保存、取得

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -7,5 +7,9 @@ service cloud.firestore {
       allow update: if request.auth.uid == resource.data.userId && resource.data.userId == request.resource.data.userId;
       allow delete: if request.auth.uid == resource.data.userId;
     }
+    match /users/{userId} {
+      allow read: if true;
+      allow write: if request.auth.uid == userId;
+    }
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,8 +1,14 @@
-// import * as functions from 'firebase-functions';
+import * as functions from 'firebase-functions';
+import * as admin from 'firebase-admin'
 
-// // Start writing Firebase Functions
-// // https://firebase.google.com/docs/functions/typescript
-//
-// export const helloWorld = functions.https.onRequest((request, response) => {
-//  response.send("Hello from Firebase!");
-// });
+admin.initializeApp();
+const db = admin.firestore();
+
+export const createUser = functions.region('asia-northeast1').auth.user().onCreate((user) => {
+  return db.doc(`users/${user.uid}`).set({
+    uId: user.uid,
+    uName: user.displayName,
+    avatarURL: user.photoURL,
+    screenName: null,
+  });
+});

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -30,8 +30,6 @@ const routes: Routes = [
     path: ':id',
     loadChildren: () =>
       import('./mypage/mypage.module').then((m) => m.MypageModule),
-    canLoad: [AuthGuard],
-    canActivate: [AuthGuard]
   },
   {
     path: '',

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -10,7 +10,7 @@
 
     <ng-template #default>
       <button [disabled]="isProcessing" (click)="login()" mat-flat-button color="primary" medium class="login-button">
-        <span>Twitterでログイン</span>
+        <span>{{isProcessing ? 'ログイン中' : 'Twitterでログイン'}}</span>
       </button>
     </ng-template>
 
@@ -22,12 +22,12 @@
         </button>
 
         <button mat-icon-button medium [matMenuTriggerFor]="menu" aria-label="マイメニュー"
-          [style.background-image]="'url(' + user.photoURL + ')'" class="my-menu">
+          [style.background-image]="'url(' + user.avatarURL + ')'" class="my-menu">
         </button>
 
 
         <mat-menu #menu="matMenu">
-          <button mat-menu-item [routerLink]="['/', user.providerData[0].uid]">
+          <button mat-menu-item [routerLink]="['/', user.screenName]">
             <mat-icon>account_box</mat-icon>
             <span>マイページ</span>
           </button>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -55,10 +55,6 @@
   background-color: #1da1f2;
 }
 
-.login-button:disabled {
-  display: none;
-}
-
 .post-button {
   background-color: #ff5500;
   margin-right: 24px;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
-import { take } from 'rxjs/operators';
+import { UserService } from '../services/user.service';
 
 @Component({
   selector: 'app-header',
@@ -8,22 +8,23 @@ import { take } from 'rxjs/operators';
   styleUrls: ['./header.component.scss']
 })
 export class HeaderComponent implements OnInit {
-  user$ = this.authService.afUser$;
-  isProcessing = true;
+  user$ = this.authService.user$;
+  isProcessing: boolean;
 
   constructor(
-    private authService: AuthService
-  ) {
-    this.user$.pipe(take(1)).subscribe(() => {
-      this.isProcessing = false;
-    });
-  }
+    private authService: AuthService,
+    private userService: UserService,
+  ) { }
 
   ngOnInit(): void {
   }
 
   login() {
-    this.authService.login();
+    this.isProcessing = true;
+    this.authService.login().finally(() => {
+      this.isProcessing = false;
+      this.userService.getUser(this.authService.uId);
+    });
   }
 
   logout() {

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -1,0 +1,6 @@
+export interface UserData {
+  uId: string;
+  uName: string;
+  avatarURL: string;
+  screenName: string;
+}

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -71,7 +71,7 @@ export class CreateComponent implements OnInit {
   submit() {
     const formData = this.form.value;
     this.articleService.createArticle({
-      userId: this.authService.uid,
+      userId: this.authService.uId,
       id: '',
       thumbnailUrl: 'http://placekitten.com/700/300',
       title: formData.title,

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(UserService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { UserData } from '../interfaces/user';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserService {
+
+  constructor(
+    private db: AngularFirestore,
+  ) { }
+
+  getUser(uId: string): Observable<UserData> {
+    return this.db.doc<UserData>(`users/${uId}`).valueChanges();
+  }
+
+  updateUser(uId: string, uName: string, avatarURL: string, screenName: string): Promise<void> {
+    return this.db.doc<UserData>(`users/${uId}`).update(
+      {
+        uId, uName, avatarURL, screenName
+      }
+    );
+  }
+
+  deleteUser(uId: string): Promise<void> {
+    return this.db.doc<UserData>(`users/${uId}`).delete();
+  }
+}


### PR DESCRIPTION
fix #57 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 作業概要

- firestoreRuleの設定
- userDataインターフェースの作成
- ログインをポップアップに変更し、ログイン時にscreenNameを取得、そのタイミングでログインユーザー情報をFirestoreに保存
- userDataをfirestoreから取得し、ヘッダーでasyncパイプで受け取る
- mypage画面へのリンクのルートパラメーターをscreenNameにする
- mypage画面のガードを外す