### PR TITLE
home, mypage, noteでユーザー&記事データを表示、記事コンポーネントのマークアップ、スタイル調整

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,8 +6,8 @@ const db = admin.firestore();
 
 export const createUser = functions.region('asia-northeast1').auth.user().onCreate((user) => {
   return db.doc(`users/${user.uid}`).set({
-    uId: user.uid,
-    uName: user.displayName,
+    uid: user.uid,
+    userName: user.displayName,
     avatarURL: user.photoURL,
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2733,23 +2733,16 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.5.tgz",
-      "integrity": "sha512-p+h1s9A8EjGWfjAObu8ei46JoN2Ogbtl1RzqW7HjcPuclOIOmPTXKEXXCEXgO79OLxnzzezVeBtHPSx6r6gxJA==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.8.tgz",
+      "integrity": "sha512-HpNRBJHnrGq5jtVTNRgA8Ozng2ilt0pkej8D5EvXoaylu80U+ICKLBlIT8TdUSEfkXC/RPjvLXg6vn/sq/CyqA==",
       "requires": {
         "@firebase/analytics-types": "0.3.1",
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "@firebase/component": "0.1.15",
+        "@firebase/installations": "0.4.13",
+        "@firebase/logger": "0.2.5",
+        "@firebase/util": "0.2.50",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/analytics-types": {
@@ -2758,24 +2751,17 @@
       "integrity": "sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA=="
     },
     "@firebase/app": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.4.tgz",
-      "integrity": "sha512-E1Zw6yeZYdYYFurMnklKPvE+q/xleHXs7bmcVgyhgAEg3Gv6/qXI4+4GdWh+iF7wmQ3Liesh51xqfdpvHBwAMQ==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.7.tgz",
+      "integrity": "sha512-6NpIZ3iMrCR2XOShK5oi3YYB0GXX5yxVD8p3+2N+X4CF5cERyIrDRf8+YXOFgr+bDHSbVcIyzpWv6ijhg4MJlw==",
       "requires": {
         "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.12",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/component": "0.1.15",
+        "@firebase/logger": "0.2.5",
+        "@firebase/util": "0.2.50",
         "dom-storage": "2.1.0",
-        "tslib": "1.11.1",
+        "tslib": "^1.11.1",
         "xmlhttprequest": "1.8.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
       }
     },
     "@firebase/app-types": {
@@ -2784,9 +2770,9 @@
       "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
     },
     "@firebase/auth": {
-      "version": "0.14.6",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.6.tgz",
-      "integrity": "sha512-7gaEUWhUubWBGfOXAZvpTpJqBJT9KyG83RXC6VnjSQIfNUaarHZ485WkzERil43A6KvIl+f4kHxfZShE6ZCK3A==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.14.7.tgz",
+      "integrity": "sha512-NTQY9luV70XUA6zGYOWloDSaOT+l0/R4u3W7ptqVCfZNc4DAt7euUkTbj7SDD14902sHF54j+tk5kmpEmMd0jA==",
       "requires": {
         "@firebase/auth-types": "0.10.1"
       }
@@ -2802,33 +2788,26 @@
       "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw=="
     },
     "@firebase/component": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.12.tgz",
-      "integrity": "sha512-03w800MxR/EW1m7N0Q46WNcngwdDIHDWpFPHTdbZEI6U/HuLks5RJQlBxWqb1P73nYPkN8YP3U8gTdqrDpqY3Q==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.15.tgz",
+      "integrity": "sha512-HqFb1qQl1vtlUMIzPM15plNz27jqM8DWjuQQuGeDfG+4iRRflwKfgNw1BOyoP4kQ8vOBCL7t/71yPXSomNdJdQ==",
       "requires": {
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "@firebase/util": "0.2.50",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/database": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.3.tgz",
-      "integrity": "sha512-gHoCISHQVLoq+rGu+PorYxMkhsjhXov3ocBxz/0uVdznNhrbKkAZaEKF+dIAsUPDlwSYeZuwWuik7xcV3DtRaw==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.6.tgz",
+      "integrity": "sha512-TqUJOaCATF/h3wpqhPT9Fz1nZI6gBv/M2pHZztUjX4A9o9Bq93NyqUurYiZnGB7zpSkEADFCVT4f0VBrWdHlNw==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.15",
         "@firebase/database-types": "0.5.1",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/logger": "0.2.5",
+        "@firebase/util": "0.2.50",
         "faye-websocket": "0.11.3",
-        "tslib": "1.11.1"
+        "tslib": "^1.11.1"
       },
       "dependencies": {
         "faye-websocket": {
@@ -2838,11 +2817,6 @@
           "requires": {
             "websocket-driver": ">=0.5.1"
           }
-        },
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
         }
       }
     },
@@ -2855,62 +2829,35 @@
       }
     },
     "@firebase/firestore": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.14.6.tgz",
-      "integrity": "sha512-9TfM4BFQAhyn+gmayX80wZEAO27bUBy471pba/oAYM9UrvPp1US9Bn/QzeuA/hxBSZXcN5zWNcs1Ibyt8eAreg==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.15.5.tgz",
+      "integrity": "sha512-unkRIC2hL2Ge5er/Hj43aUYiEKlW5bpju8TnIaF33avg/wZpSsmtVrMlAQVkBWFhvWeYpJSr2QOzNLa1bQvuCA==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/firestore-types": "1.10.3",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/component": "0.1.15",
+        "@firebase/firestore-types": "1.11.0",
+        "@firebase/logger": "0.2.5",
+        "@firebase/util": "0.2.50",
         "@firebase/webchannel-wrapper": "0.2.41",
-        "@grpc/grpc-js": "0.8.1",
+        "@grpc/grpc-js": "^1.0.0",
         "@grpc/proto-loader": "^0.5.0",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "@grpc/grpc-js": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.8.1.tgz",
-          "integrity": "sha512-e8gSjRZnOUefsR3obOgxG9RtYW2Mw83hh7ogE2ByCdgRhoX0mdnJwBcZOami3E0l643KCTZvORFwfSEi48KFIQ==",
-          "requires": {
-            "semver": "^6.2.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.10.3.tgz",
-      "integrity": "sha512-DcYTJbva/gYK3i9q1Jw4tUkuSGQY5tXizSU/yytJgsRZNQrLEbrbHza9n6MAxcBbMSgcWZ24XzCGELtlKgMbSw=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.11.0.tgz",
+      "integrity": "sha512-hD7+cmMUvT5OJeWVrcRkE87PPuj/0/Wic6bntCopJE1WIX/Dm117AUkHgKd3S7Ici6DLp4bdlx1MjjwWL5942w=="
     },
     "@firebase/functions": {
-      "version": "0.4.44",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.44.tgz",
-      "integrity": "sha512-Nbw+V/jYqfgq7wscsSDidqIzx8TrnmA2wRD1auCFNmf+gSJg8o+gNyCDdNHZI407jvrZcxp3nG1eMbqwmmnp7Q==",
+      "version": "0.4.47",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.47.tgz",
+      "integrity": "sha512-wiyMezW1EYq80Uk15M4poapCG10PjN5UJEY0jJr7DhCnDAoADMGlsIYFYio60+biGreij5/hpOybw5mU9WpXUw==",
       "requires": {
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.15",
         "@firebase/functions-types": "0.3.17",
         "@firebase/messaging-types": "0.4.5",
         "isomorphic-fetch": "2.2.1",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/functions-types": {
@@ -2919,22 +2866,15 @@
       "integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ=="
     },
     "@firebase/installations": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.10.tgz",
-      "integrity": "sha512-Nf7VK9++0eQzjdvBkBNNaOdxPjFiKD0EllLCIQycHozF97BmuFUqb2Ik5L2JaWspWg7vxLNacLHvW48nPGx4Zw==",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.13.tgz",
+      "integrity": "sha512-Sic7BtWgdUwk+Z1C4L49Edkhzaol/ijEIdv0pkHfjedIPirIU2V8CJ5qykx2y4aTiyVbdFqfjIpp1c6A6W3GBA==",
       "requires": {
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.15",
         "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.2.50",
         "idb": "3.0.2",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/installations-types": {
@@ -2943,28 +2883,21 @@
       "integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q=="
     },
     "@firebase/logger": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.4.tgz",
-      "integrity": "sha512-akHkOU7izYB1okp/B5sxClGjjw6KvZdSHyjNM5pKd67Zg5W6PsbkI/GFNv21+y6LkUkJwDRbdeDgJoYXWT3mMA=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.5.tgz",
+      "integrity": "sha512-qqw3m0tWs/qrg7axTZG/QZq24DIMdSY6dGoWuBn08ddq7+GLF5HiqkRj71XznYeUUbfRq5W9C/PSFnN4JxX+WA=="
     },
     "@firebase/messaging": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.16.tgz",
-      "integrity": "sha512-TAPISK5y3xbxUw81HxLDP6YPsRryU6Nl8Z7AjNnem13BoN9LJ2/wCi9RDMfPnQhAn0h0N+mpxy/GB+0IlEARlg==",
+      "version": "0.6.19",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.19.tgz",
+      "integrity": "sha512-PhqK69m70G+GGgvbdnGz2+PyoqfmR5b+nouj1JV+HgyBCjMAhF8rDYQzCWWgy4HaWbLoS/xW6AZUKG20Kv2H1A==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
+        "@firebase/component": "0.1.15",
+        "@firebase/installations": "0.4.13",
         "@firebase/messaging-types": "0.4.5",
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.2.50",
         "idb": "3.0.2",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/messaging-types": {
@@ -2973,23 +2906,16 @@
       "integrity": "sha512-sux4fgqr/0KyIxqzHlatI04Ajs5rc3WM+WmtCpxrKP1E5Bke8xu/0M+2oy4lK/sQ7nov9z15n3iltAHCgTRU3Q=="
     },
     "@firebase/performance": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.5.tgz",
-      "integrity": "sha512-FCUxK3IsJuthSosXzCA/B3Lz0o51QLjS1PuHFSxW4zwnMN2p5LrJBof47D2qB/ZYLey8xR4u2IGHOjvSDyKA9w==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.8.tgz",
+      "integrity": "sha512-jODXrtFLyfnRiBehHuMBmsBtMv38U9sTictRxJSz+9JahvWYm1AF0YDzPlfeyYj+kxM6+S5wdQxUaPVdcWAvWg==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
+        "@firebase/component": "0.1.15",
+        "@firebase/installations": "0.4.13",
+        "@firebase/logger": "0.2.5",
         "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "@firebase/util": "0.2.50",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/performance-types": {
@@ -3020,23 +2946,16 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.21.tgz",
-      "integrity": "sha512-EwDNU1mT+8Jn66IUwwNP5SM8AbaI7wmCXjp7djZtTXNrpPoh3xqzSRM1vTgp4Uu/mHffEDfbydsoJAIftADIfQ==",
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.24.tgz",
+      "integrity": "sha512-/Kd+I5mNPI2wJJFySOC8Mjj4lRnEwZhU0RteuVlzFCDWWEyTE//r+p2TLAufQ9J+Fd3Ru5fVMFLNyU8k71Viiw==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
+        "@firebase/component": "0.1.15",
+        "@firebase/installations": "0.4.13",
+        "@firebase/logger": "0.2.5",
         "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "@firebase/util": "0.2.50",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/remote-config-types": {
@@ -3045,21 +2964,14 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "@firebase/storage": {
-      "version": "0.3.34",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.34.tgz",
-      "integrity": "sha512-vuR1PpGdaCk25D2dT2trfmZZjpdfOn0rPTksvoqg7TAPLeoVsVoDyT2LgF3Arna/jqx52sAIRx1HLrlvzE1pgA==",
+      "version": "0.3.37",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.37.tgz",
+      "integrity": "sha512-RLbiRQlnvXRP/30OaEiUoRHBxZygqrZyotPPWD2WmD3JMM9qGTVpYNQ092mqL3R8ViyejwlpjlPvrDo7Z9BzgQ==",
       "requires": {
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.15",
         "@firebase/storage-types": "0.3.12",
-        "@firebase/util": "0.2.47",
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "@firebase/util": "0.2.50",
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/storage-types": {
@@ -3068,18 +2980,11 @@
       "integrity": "sha512-DDV6Fs6aYoGw3w/zZZTkqiipxihnsvHf6znbeZYjIIHit3tr1uLJdGPDPiCTfZcTGPpg2ux6ZmvNDvVgJdHALw=="
     },
     "@firebase/util": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.47.tgz",
-      "integrity": "sha512-RjcIvcfswyxYhf0OMXod+qeI/933wl9FGLIszf0/O1yMZ/s8moXcse7xnOpMjmQPRLB9vHzCMoxW5X90kKg/bQ==",
+      "version": "0.2.50",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.50.tgz",
+      "integrity": "sha512-vFE6+Jfc25u0ViSpFxxq0q5s+XmuJ/y7CL3ud79RQe+WLFFg+j0eH1t23k0yNSG9vZNM7h3uHRIXbV97sYLAyw==",
       "requires": {
-        "tslib": "1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-          "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
-        }
+        "tslib": "^1.11.1"
       }
     },
     "@firebase/webchannel-wrapper": {
@@ -3187,7 +3092,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.4.tgz",
       "integrity": "sha512-Qawt6HUrEmljQMPWnLnIXpcjelmtIAydi3M9awiG02WWJ1CmIvFEx4IOC1EsWUWUlabOGksRbpfvoIeZKFTNXw==",
-      "dev": true,
       "requires": {
         "google-auth-library": "^6.0.0",
         "semver": "^6.2.0"
@@ -3197,7 +3101,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
           "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
-          "dev": true,
           "requires": {
             "debug": "4"
           }
@@ -3205,14 +3108,12 @@
         "arrify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-          "dev": true
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
         },
         "gaxios": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.3.tgz",
           "integrity": "sha512-PkzQludeIFhd535/yucALT/Wxyj/y2zLyrMwPcJmnLHDugmV49NvAi/vb+VUq/eWztATZCNcb8ue+ywPG+oLuw==",
-          "dev": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -3225,7 +3126,6 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.0.tgz",
           "integrity": "sha512-r57SV28+olVsflPlKyVig3Muo/VDlcsObMtvDGOEtEJXj+DDE8bEl0coIkXh//hbkSDTvo+f5lbihZOndYXQQQ==",
-          "dev": true,
           "requires": {
             "gaxios": "^3.0.0",
             "json-bigint": "^0.3.0"
@@ -3235,7 +3135,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.0.tgz",
           "integrity": "sha512-uLydy1t6SHN/EvYUJrtN3GCHFrnJ0c8HJjOxXiGjoTuYHIoCUT3jVxnzmjHwVnSdkfE9Akasm2rM6qG1COTXfQ==",
-          "dev": true,
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
@@ -3252,7 +3151,6 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.1.tgz",
           "integrity": "sha512-VlQgtozgNVVVcYTXS36eQz4PXPt9gIPqLOhHN0QiV6W6h4qSCNVKPtKC5INtJsaHHF2r7+nOIa26MJeJMTaZEQ==",
-          "dev": true,
           "requires": {
             "node-forge": "^0.9.0"
           }
@@ -3261,7 +3159,6 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.1.tgz",
           "integrity": "sha512-33w4FNDkUcyIOq/TqyC+drnKdI4PdXmWp9lZzssyEQKuvu9ZFN3KttaSnDKo52U3E51oujVGop93mKxmqO8HHg==",
-          "dev": true,
           "requires": {
             "gaxios": "^3.0.0",
             "google-p12-pem": "^3.0.0",
@@ -3273,7 +3170,6 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
           "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-          "dev": true,
           "requires": {
             "agent-base": "6",
             "debug": "4"
@@ -3282,20 +3178,17 @@
         "is-stream": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
         },
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -3809,7 +3702,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "dev": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -4394,8 +4286,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "base64id": {
       "version": "2.0.0",
@@ -4457,8 +4348,7 @@
     "bignumber.js": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
-      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
-      "dev": true
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
     "binary": {
       "version": "0.3.0",
@@ -4803,8 +4693,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
-      "dev": true
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -6352,7 +6241,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -6779,7 +6667,6 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -7144,8 +7031,7 @@
     "event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
     },
     "eventemitter3": {
       "version": "4.0.4",
@@ -7342,8 +7228,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -7469,8 +7354,7 @@
     "fast-text-encoding": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.2.tgz",
-      "integrity": "sha512-5rQdinSsycpzvAoHga2EDn+LRX1d5xLFsuNG0Kg61JrAT/tASXcLL0nf/33v+sAxlQcfYmWbTURa1mmAf55jGw==",
-      "dev": true
+      "integrity": "sha512-5rQdinSsycpzvAoHga2EDn+LRX1d5xLFsuNG0Kg61JrAT/tASXcLL0nf/33v+sAxlQcfYmWbTURa1mmAf55jGw=="
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -7695,24 +7579,24 @@
       }
     },
     "firebase": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.14.6.tgz",
-      "integrity": "sha512-W7nN57T+slfSYtUoCD7Jup/P+V8velhjbtJUlO4+gYXCG0TT83ah3B+89LlVwOrL3tVAl68GdA892vdXVsY6zQ==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.15.5.tgz",
+      "integrity": "sha512-yeXo3KDp/ZWO0/Uyen99cUvGM76femebmyNOBTHcGSDkBXvIGth6235KhclxLROIKCC5b3YNwmKX11tbaC6RJg==",
       "requires": {
-        "@firebase/analytics": "0.3.5",
-        "@firebase/app": "0.6.4",
+        "@firebase/analytics": "0.3.8",
+        "@firebase/app": "0.6.7",
         "@firebase/app-types": "0.6.1",
-        "@firebase/auth": "0.14.6",
-        "@firebase/database": "0.6.3",
-        "@firebase/firestore": "1.14.6",
-        "@firebase/functions": "0.4.44",
-        "@firebase/installations": "0.4.10",
-        "@firebase/messaging": "0.6.16",
-        "@firebase/performance": "0.3.5",
+        "@firebase/auth": "0.14.7",
+        "@firebase/database": "0.6.6",
+        "@firebase/firestore": "1.15.5",
+        "@firebase/functions": "0.4.47",
+        "@firebase/installations": "0.4.13",
+        "@firebase/messaging": "0.6.19",
+        "@firebase/performance": "0.3.8",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.21",
-        "@firebase/storage": "0.3.34",
-        "@firebase/util": "0.2.47"
+        "@firebase/remote-config": "0.1.24",
+        "@firebase/storage": "0.3.37",
+        "@firebase/util": "0.2.50"
       }
     },
     "firebase-tools": {
@@ -9948,7 +9832,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
       "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
-      "dev": true,
       "requires": {
         "bignumber.js": "^7.0.0"
       }
@@ -10097,7 +9980,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
       "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-      "dev": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -10108,7 +9990,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-      "dev": true,
       "requires": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -10641,7 +10522,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
       "requires": {
         "yallist": "^3.0.2"
       },
@@ -10649,8 +10529,7 @@
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -11283,8 +11162,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -11390,8 +11268,7 @@
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-fetch-npm": {
       "version": "2.0.4",
@@ -11407,8 +11284,7 @@
     "node-forge": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
-      "dev": true
+      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ=="
     },
     "node-libs-browser": {
       "version": "2.2.1",
@@ -17438,9 +17314,9 @@
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.1.0.tgz",
+      "integrity": "sha512-pgmbsVWKpH9GxLXZmtdowDIqtb/rvPyjjQv3z9wLcmgWKFHilKnZD3ldgrOlwJoPGOUluQsRPWd52yVkPfmI1A=="
     },
     "when": {
       "version": "3.6.4",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^9.1.9",
     "@angular/router": "^9.1.9",
     "@kolkov/angular-editor": "^1.1.2",
-    "firebase": "^7.14.6",
+    "firebase": "^7.15.5",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.2"

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -1,5 +1,5 @@
 .footer {
-  background-color: #f5f5f5;
+  background-color: inherit;
   padding: 16px;
   &__nav {
     display: flex;

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -6,6 +6,7 @@
   display: flex;
   height: 70px;
   border-bottom: solid 1px #e0e0e0;
+  box-shadow: 0 0px 2px 1px #3c3c3c4d, 0 0px 4px 2px #3c3c3c26;
   &__container {
     max-width: 1000px;
     height: 100%;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
-import { UserService } from '../services/user.service';
 
 @Component({
   selector: 'app-header',
@@ -13,7 +12,6 @@ export class HeaderComponent implements OnInit {
 
   constructor(
     private authService: AuthService,
-    private userService: UserService,
   ) { }
 
   ngOnInit(): void {
@@ -23,7 +21,6 @@ export class HeaderComponent implements OnInit {
     this.isProcessing = true;
     this.authService.login().finally(() => {
       this.isProcessing = false;
-      this.userService.getUserByUId(this.authService.uId);
     });
   }
 

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -28,10 +28,10 @@ export class HomeComponent implements OnInit {
 
         if (articles.length) {
           const authorIds: string[] = articles.filter((article, index, self) => {
-            return self.findIndex(item => article.uId === item.uId) === index;
-          }).map(post => post.uId);
-          return combineLatest(authorIds.map(uId => {
-            return this.userService.getUserByUId(uId);
+            return self.findIndex(item => article.uid === item.uid) === index;
+          }).map(post => post.uid);
+          return combineLatest(authorIds.map(uid => {
+            return this.userService.getUserData(uid);
           }));
         } else {
           return of([]);
@@ -41,7 +41,7 @@ export class HomeComponent implements OnInit {
         return articles.map(article => {
           const result: ArticleWithAuthor = {
             ...article,
-            author: users.find(user => user.uId === article.uId),
+            author: users.find(user => user.uid === article.uid),
           };
           return result;
         });

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { Article } from 'src/app/interfaces/article';
+import { Article, ArticleWithAuthor } from 'src/app/interfaces/article';
+import { UserData } from 'src/app/interfaces/user';
 import { ArticleService } from 'src/app/services/article.service';
-import { Observable } from 'rxjs';
+import { Observable, of, combineLatest } from 'rxjs';
+import { switchMap, map } from 'rxjs/operators';
+import { UserService } from 'src/app/services/user.service';
 
 @Component({
   selector: 'app-home',
@@ -9,9 +12,42 @@ import { Observable } from 'rxjs';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
-  articles$: Observable<Article[]> = this.articleService.getAllArticles();
+  articles$: Observable<ArticleWithAuthor[]> = this.getArticlesWithAuthors();
+
   constructor(
     private articleService: ArticleService,
+    private userService: UserService,
   ) { }
+
+  getArticlesWithAuthors(): Observable<ArticleWithAuthor[]> {
+    let articles: Article[];
+
+    return this.articleService.getAllArticles().pipe(
+      switchMap((docs: Article[]) => {
+        articles = docs;
+
+        if (articles.length) {
+          const authorIds: string[] = articles.filter((article, index, self) => {
+            return self.findIndex(item => article.uId === item.uId) === index;
+          }).map(post => post.uId);
+          return combineLatest(authorIds.map(uId => {
+            return this.userService.getUserByUId(uId);
+          }));
+        } else {
+          return of([]);
+        }
+      }),
+      map((users: UserData[]) => {
+        return articles.map(article => {
+          const result: ArticleWithAuthor = {
+            ...article,
+            author: users.find(user => user.uId === article.uId),
+          };
+          return result;
+        });
+      })
+    );
+  }
+
   ngOnInit(): void { }
 }

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -1,5 +1,5 @@
 import { UserData } from './user';
-import { firestore } from 'firebase';
+import { firestore } from 'firebase/app';
 
 export interface Article {
   uId: string;

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -1,7 +1,7 @@
 export interface Article {
-  userId: string;
-  id: string;
-  thumbnailUrl: string;
+  uId: string;
+  aId: string;
+  imageURL: string;
   title: string;
   tag: string;
   text: string;

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -2,8 +2,8 @@ import { UserData } from './user';
 import { firestore } from 'firebase/app';
 
 export interface Article {
-  uId: string;
-  aId: string;
+  articleId: string;
+  uid: string;
   imageURL: string;
   title: string;
   tag: string;

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -1,4 +1,6 @@
 import { UserData } from './user';
+import { firestore } from 'firebase';
+
 export interface Article {
   uId: string;
   aId: string;
@@ -6,6 +8,8 @@ export interface Article {
   title: string;
   tag: string;
   text: string;
+  createdAt: firestore.Timestamp;
+  updatedAt: firestore.Timestamp;
 }
 
 export interface ArticleWithAuthor extends Article {

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -1,3 +1,4 @@
+import { UserData } from './user';
 export interface Article {
   uId: string;
   aId: string;
@@ -5,4 +6,8 @@ export interface Article {
   title: string;
   tag: string;
   text: string;
+}
+
+export interface ArticleWithAuthor extends Article {
+  author: UserData;
 }

--- a/src/app/interfaces/user.ts
+++ b/src/app/interfaces/user.ts
@@ -1,6 +1,6 @@
 export interface UserData {
-  uId: string;
-  uName: string;
+  uid: string;
+  userName: string;
   avatarURL: string;
   screenName: string;
   description: string;

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -2,7 +2,7 @@
   <div class="mypage__profile">
     <ng-container *ngIf="user$ | async as user; else notFound;">
       <img [src]="user.avatarURL" class="mypage__user-icon">
-      <h2 class="mypage__user-name">{{user.uName}}</h2>
+      <h2 class="mypage__user-name">{{user.userName}}</h2>
       <p class="mypage__screen-name">@{{user.screenName}}</p>
       <a [href]="'https://twitter.com/' + user.screenName">
         <img src="/assets/icons/twitter.png" alt="twitterアイコン" class="mypage__twitter-icon">

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -31,10 +31,10 @@ export class MypageComponent implements OnInit {
       this.articles$ = this.user$.pipe(
         map((user: UserData) => {
           author = user;
-          return user.uId;
+          return user.uid;
         }),
-        switchMap((uId) => {
-          return this.articleService.getArticlesByUId(uId);
+        switchMap((uid) => {
+          return this.articleService.getArticles(uid);
         }),
         map((articles: Article[]) => {
           return articles.map(article => {

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -27,18 +27,25 @@ export class MypageComponent implements OnInit {
       this.user$ = this.userService.getUserByScreenName(
         this.screenName
       );
-      // this.articles$ = this.user$.pipe(
-      //   map((user: UserData) => user.uId),
-      //   switchMap((uId: string) => this.articleService.getArticlesByUId(uId))),
-      //   map((articles: Article[]) => {
-      //     articles.map(article => {
-      //       const result: ArticleWithAuthor = {
-      //         ...article,
-      //         author: ,
-      //       };
-      //       return result;
-      //     });
-      //   });
+      let author: UserData;
+      this.articles$ = this.user$.pipe(
+        map((user: UserData) => {
+          author = user;
+          return user.uId;
+        }),
+        switchMap((uId) => {
+          return this.articleService.getArticlesByUId(uId);
+        }),
+        map((articles: Article[]) => {
+          return articles.map(article => {
+            const result: ArticleWithAuthor = {
+              ...article,
+              author,
+            };
+            return result;
+          });
+        })
+      );
     });
   }
 

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -3,7 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { UserService } from 'src/app/services/user.service';
 import { Observable } from 'rxjs';
 import { UserData } from 'src/app/interfaces/user';
-import { Article } from 'src/app/interfaces/article';
+import { Article, ArticleWithAuthor } from 'src/app/interfaces/article';
 import { ArticleService } from 'src/app/services/article.service';
 import { map, switchMap } from 'rxjs/operators';
 
@@ -15,7 +15,7 @@ import { map, switchMap } from 'rxjs/operators';
 export class MypageComponent implements OnInit {
   user$: Observable<UserData>;
   screenName: string;
-  articles$: Observable<Article[]>;
+  articles$: Observable<ArticleWithAuthor[]>;
 
   constructor(
     private route: ActivatedRoute,
@@ -27,9 +27,18 @@ export class MypageComponent implements OnInit {
       this.user$ = this.userService.getUserByScreenName(
         this.screenName
       );
-      this.articles$ = this.user$.pipe(
-        map((user: UserData) => user.uId),
-        switchMap((uId: string) => this.articleService.getArticlesByUId(uId)));
+      // this.articles$ = this.user$.pipe(
+      //   map((user: UserData) => user.uId),
+      //   switchMap((uId: string) => this.articleService.getArticlesByUId(uId))),
+      //   map((articles: Article[]) => {
+      //     articles.map(article => {
+      //       const result: ArticleWithAuthor = {
+      //         ...article,
+      //         author: ,
+      //       };
+      //       return result;
+      //     });
+      //   });
     });
   }
 

--- a/src/app/mypage/note/note.component.html
+++ b/src/app/mypage/note/note.component.html
@@ -1,61 +1,65 @@
 <div class="note">
-  <div class="note-header">
-    <div class="note-header__author">
-      <a href="#">
-        <img src='https://placehold.it/40x40' alt='ユーザーアイコン' class="note-header__user-icon" />
-      </a>
-      <a href="#" class="note-header__user-name">
-        こむら
-      </a>
-      <a class="note-header__twitter">
-        <img src="/assets/icons/twitter.png" alt="twitterアイコン">
-      </a>
-      <p class="note-header__updated-date">2020年10月10日に更新</p>
-    </div>
-    <h1 class="note-header__title">Logic Pro Xの大型アップデートの変更内容
-    </h1>
-    <a href="#" class="note-header__tag">DTM</a>
-    <a href="#" class="note-header__tag">Sylenth1</a>
-  </div>
-  <div class="note__content">
-    <h2>はじめに</h2>
-    <p>今回のLogicProのアップデートではEXS24がSamplerになりました</p>
-    <h2>Samplerの変更点</h2>
-    <p>以前よりもサンプルを加工しやすくなった。パラメーターが以下の通り増えている。</p>
-    <br>
-    <p>実際に</p>
-    <img src='https://placehold.it/800x200' alt='イメージ1' />
-    <p>ということだ</p>
-  </div>
-  <div class="note-footer">
-    <div class="actions">
-      <button mat-icon-button color="warn" class="actions__favorite" aria-label="いいね" matTooltip="いいね">
-        <mat-icon>favorite</mat-icon>
-      </button>
-      <div class="actions__share">
-        <button mat-icon-button class="actions__twitter" aria-label="Twitterでシェア" matTooltip="Twitterでシェア">
+  <ng-container *ngIf="article$ | async as article; else notFound;">
+    <div class="note-header">
+      <div class="note-header__author">
+        <a [routerLink]="'/'  + article.author.screenName">
+          <img class="note-header__user-icon" [src]="article.author.avatarURL" alt="ユーザーアイコン"></a>
+        <a class="note-header__user-name" [routerLink]="'/' + article.author.screenName">{{article.author.uName}}</a>
+        <a class="note-header__twitter" [href]="'https://twitter.com/' + article.author.screenName">
           <img src="/assets/icons/twitter.png" alt="twitterアイコン">
-        </button>
-        <button mat-icon-button href="#" class="actions__link" aria-label="リンクをコピー" matTooltip="リンクをコピー">
-          <mat-icon>link</mat-icon>
-        </button>
-      </div>
-    </div>
-    <div class="note-footer__author">
-      <a href="#">
-        <img src='https://placehold.it/40x40' alt='ユーザーアイコン' class="note-footer__user-icon" />
-      </a>
-      <div class="note-footer__user-profile">
-        <a class="note-footer__user-name">
-          こむら
         </a>
-        <p class="note-footer__user-text">インターネットと音楽が好きです</p>
-        <p>SNSでコメントを送ろう
+        <p class="note-header__updated-date">
+          {{ article.createdAt.toDate() | date: 'yyyy年MM月dd日' }}更新
         </p>
-        <a>
-          <img class="note-footer__twitter" src="/assets/icons/twitter.png" alt="twitterアイコン">
+      </div>
+      <h1 class="note-header__title">{{article.title}}
+      </h1>
+      <a href="#" class="note-header__tag">DTM</a>
+      <a href="#" class="note-header__tag">Sylenth1</a>
+    </div>
+    <div class="note__content">
+      <h2>はじめに</h2>
+      <p>今回のLogicProのアップデートではEXS24がSamplerになりました</p>
+      <h2>Samplerの変更点</h2>
+      <p>以前よりもサンプルを加工しやすくなった。パラメーターが以下の通り増えている。</p>
+      <br>
+      <p>実際に</p>
+      <img src='https://placehold.it/800x200' alt='イメージ1' />
+      <p>ということだ</p>
+    </div>
+    <div class="note-footer">
+      <div class="actions">
+        <button mat-icon-button color="warn" class="actions__favorite" aria-label="いいね" matTooltip="いいね">
+          <mat-icon>favorite</mat-icon>
+        </button>
+        <div class="actions__share">
+          <button mat-icon-button class="actions__twitter" aria-label="Twitterでシェア" matTooltip="Twitterでシェア">
+            <img src="/assets/icons/twitter.png" alt="twitterアイコン">
+          </button>
+          <button mat-icon-button href="#" class="actions__link" aria-label="リンクをコピー" matTooltip="リンクをコピー">
+            <mat-icon>link</mat-icon>
+          </button>
+        </div>
+      </div>
+      <div class="note-footer__author">
+        <a href="#">
+          <img src='https://placehold.it/40x40' alt='ユーザーアイコン' class="note-footer__user-icon" />
         </a>
+        <div class="note-footer__user-profile">
+          <a class="note-footer__user-name">
+            こむら
+          </a>
+          <p class="note-footer__user-text">インターネットと音楽が好きです</p>
+          <p>SNSでコメントを送ろう
+          </p>
+          <a>
+            <img class="note-footer__twitter" src="/assets/icons/twitter.png" alt="twitterアイコン">
+          </a>
+        </div>
       </div>
     </div>
-  </div>
+  </ng-container>
+  <ng-template #notFound>
+    <p class="error">「{{articleId}}」という記事は存在しませんでした。</p>
+  </ng-template>
 </div>

--- a/src/app/mypage/note/note.component.html
+++ b/src/app/mypage/note/note.component.html
@@ -4,7 +4,7 @@
       <div class="note-header__author">
         <a [routerLink]="'/'  + article.author.screenName">
           <img class="note-header__user-icon" [src]="article.author.avatarURL" alt="ユーザーアイコン"></a>
-        <a class="note-header__user-name" [routerLink]="'/' + article.author.screenName">{{article.author.uName}}</a>
+        <a class="note-header__user-name" [routerLink]="'/' + article.author.screenName">{{article.author.userName}}</a>
         <a class="note-header__twitter" [href]="'https://twitter.com/' + article.author.screenName">
           <img src="/assets/icons/twitter.png" alt="twitterアイコン">
         </a>

--- a/src/app/mypage/note/note.component.ts
+++ b/src/app/mypage/note/note.component.ts
@@ -1,4 +1,11 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { ArticleWithAuthor, Article } from 'src/app/interfaces/article';
+import { ArticleService } from 'src/app/services/article.service';
+import { Observable } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import { UserService } from 'src/app/services/user.service';
+import { UserData } from 'src/app/interfaces/user';
 
 @Component({
   selector: 'app-note',
@@ -6,8 +13,36 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./note.component.scss']
 })
 export class NoteComponent implements OnInit {
+  article$: Observable<ArticleWithAuthor>;
+  articleId: string;
 
-  constructor() { }
+  constructor(
+    private route: ActivatedRoute,
+    private articleService: ArticleService,
+    private userService: UserService,
+  ) {
+    route.paramMap.subscribe(params => {
+      this.articleId = params.get('id');
+      const post$ = this.articleService.getArticleByAId(this.articleId);
+      let articleData: Article;
+      this.article$ = post$.pipe(
+        map((article: Article) => {
+          articleData = article;
+          return article.uId;
+        }),
+        switchMap((uId: string) => {
+          return this.userService.getUserByUId(uId);
+        }),
+        map((author: UserData) => {
+          const result: ArticleWithAuthor = {
+            ...articleData,
+            author,
+          };
+          return result;
+        })
+      );
+    });
+  }
 
   ngOnInit(): void {
   }

--- a/src/app/mypage/note/note.component.ts
+++ b/src/app/mypage/note/note.component.ts
@@ -23,15 +23,15 @@ export class NoteComponent implements OnInit {
   ) {
     route.paramMap.subscribe(params => {
       this.articleId = params.get('id');
-      const post$ = this.articleService.getArticleByAId(this.articleId);
+      const post$ = this.articleService.getArticleOnly(this.articleId);
       let articleData: Article;
       this.article$ = post$.pipe(
         map((article: Article) => {
           articleData = article;
-          return article.uId;
+          return article.uid;
         }),
-        switchMap((uId: string) => {
-          return this.userService.getUserByUId(uId);
+        switchMap((uid: string) => {
+          return this.userService.getUserData(uid);
         }),
         map((author: UserData) => {
           const result: ArticleWithAuthor = {

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -1,18 +1,22 @@
 <mat-card class="editor">
   <form class="editor__form" [formGroup]="form">
-    <mat-form-field class="editor__title" floatLabel="always">
-      <mat-label></mat-label>
-      <input type="text" formControlName="title" matInput placeholder="タイトル（80文字以内）*" autocomplete="off" />
-      <mat-error *ngIf="titleControl.hasError('required')">必須入力です</mat-error>
-      <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは80文字以内にしてください</mat-error>
-    </mat-form-field>
-    <mat-form-field class="editor__tag" floatLabel="always">
-      <mat-label></mat-label>
-      <input type="text" formControlName="tag" matInput placeholder="作曲やDTMに関するタグを入力" autocomplete="off" />
-    </mat-form-field>
+    <div class="editor__header">
+      <mat-form-field class="editor__title" floatLabel="always">
+        <mat-label></mat-label>
+        <input type="text" formControlName="title" matInput placeholder="タイトル（80文字以内）*" autocomplete="off" />
+        <mat-error *ngIf="titleControl.hasError('required')">必須入力です</mat-error>
+        <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは80文字以内にしてください</mat-error>
+      </mat-form-field>
+      <mat-form-field class="editor__tag" floatLabel="always">
+        <mat-label></mat-label>
+        <input type="text" formControlName="tag" matInput placeholder="作曲やDTMに関するタグを入力" autocomplete="off" />
+      </mat-form-field>
+    </div>
     <div class="editor__body">
-      <angular-editor formControlName="editorContent" class="editor__content" [config]="editorConfig">
-      </angular-editor>
+      <div class="editor__content">
+        <angular-editor formControlName="editorContent" class="editor__main" [config]="editorConfig">
+        </angular-editor>
+      </div>
       <div class="editor__preview" [innerHTML]='editorPreview'></div>
     </div>
     <div class="editor__buttons">

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -21,11 +21,11 @@
     width: 100%;
   }
   &__preview {
-    height: 430px;
+    width: 100%;
     border: 1px solid #ddd;
     padding: 12px;
     background-color: #f5f5f5;
-    overflow: scroll;
+    overflow-y: scroll;
   }
   &__buttons {
     width: 100%;

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -1,10 +1,3 @@
-::ng-deep h1,
-::ng-deep h2,
-::ng-deep h3 {
-  padding: 12px 0;
-  border-bottom: solid 1px #b6b6b6;
-}
-
 .editor {
   margin: -16px -16px -16px -16px;
   background-color: #ffffff;

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -1,19 +1,34 @@
+::ng-deep h1,
+::ng-deep h2,
+::ng-deep h3 {
+  padding: 12px 0;
+  border-bottom: solid 1px #b6b6b6;
+}
+
 .editor {
-  margin: -26px -16px -16px -16px;
+  margin: -16px -16px -16px -16px;
   background-color: #ffffff;
   &__form {
+    width: 100%;
+  }
+  &__header {
+    width: 100%;
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
+    padding: 12px 0;
   }
   &__title {
-    width: 600px;
+    width: 48%;
+    min-width: 300px;
     margin-right: 24px;
   }
   &__tag {
-    width: 600px;
+    width: 48%;
+    min-width: 300px;
   }
   &__body {
+    width: 100%;
     display: grid;
     grid-template-columns: 1fr 1fr;
   }
@@ -21,7 +36,7 @@
     width: 100%;
   }
   &__preview {
-    width: 100%;
+    width: 95%;
     border: 1px solid #ddd;
     padding: 12px;
     background-color: #f5f5f5;

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -3,6 +3,9 @@ import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { ArticleService } from 'src/app/services/article.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { AngularEditorConfig } from '@kolkov/angular-editor';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-create',
@@ -42,16 +45,19 @@ export class CreateComponent implements OnInit {
     showToolbar: true,
     placeholder: '作曲やDTMに関する知識を共有しよう',
     defaultParagraphSeparator: 'p',
-    uploadUrl: 'v1/image',
-    uploadWithCredentials: false,
     sanitize: true,
     toolbarPosition: 'top',
     toolbarHiddenButtons: [
       ['subscript',
-        'superscript', 'indent',
+        'superscript', 'justifyLeft',
+        'justifyCenter',
+        'justifyRight',
+        'justifyFull', 'indent',
         'outdent', 'fontName'],
       ['fontSize', 'textColor',
-        'backgroundColor', 'customClasses', 'insertHorizontalRule',
+        'backgroundColor', 'customClasses',
+        'insertImage',
+        'insertVideo', 'insertHorizontalRule',
         'toggleEditorMode']
     ]
   };
@@ -60,6 +66,9 @@ export class CreateComponent implements OnInit {
     private fb: FormBuilder,
     private articleService: ArticleService,
     private authService: AuthService,
+    private db: AngularFirestore,
+    private snackBar: MatSnackBar,
+    private router: Router,
   ) { }
 
   ngOnInit(): void {
@@ -70,13 +79,19 @@ export class CreateComponent implements OnInit {
 
   submit() {
     const formData = this.form.value;
+    const aId = this.db.createId();
     this.articleService.createArticle({
-      userId: this.authService.uId,
-      id: '',
-      thumbnailUrl: 'http://placekitten.com/700/300',
+      uId: this.authService.uId,
+      aId,
+      imageURL: 'http://placekitten.com/700/300',
       title: formData.title,
       tag: 'DTM',
       text: formData.editorContent,
+    }).then(() => {
+      this.router.navigateByUrl('/');
+      this.snackBar.open('記事を投稿しました', null, {
+        duration: 2000,
+      });
     });
   }
 }

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -78,9 +78,9 @@ export class CreateComponent implements OnInit {
 
   submit() {
     const formData = this.form.value;
-    const sendData: Omit<Article, 'aId' | 'createdAt' | 'updatedAt'>
+    const sendData: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt'>
       = {
-      uId: this.authService.uId,
+      uid: this.authService.uid,
       imageURL: 'http://placekitten.com/700/300',
       title: formData.title,
       tag: 'DTM',

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -3,9 +3,9 @@ import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { ArticleService } from 'src/app/services/article.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { AngularEditorConfig } from '@kolkov/angular-editor';
-import { AngularFirestore } from '@angular/fire/firestore';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
+import { Article } from 'src/app/interfaces/article';
 
 @Component({
   selector: 'app-create',
@@ -66,7 +66,6 @@ export class CreateComponent implements OnInit {
     private fb: FormBuilder,
     private articleService: ArticleService,
     private authService: AuthService,
-    private db: AngularFirestore,
     private snackBar: MatSnackBar,
     private router: Router,
   ) { }
@@ -79,15 +78,15 @@ export class CreateComponent implements OnInit {
 
   submit() {
     const formData = this.form.value;
-    const aId = this.db.createId();
-    this.articleService.createArticle({
+    const sendData: Omit<Article, 'aId' | 'createdAt' | 'updatedAt'>
+      = {
       uId: this.authService.uId,
-      aId,
       imageURL: 'http://placekitten.com/700/300',
       title: formData.title,
       tag: 'DTM',
       text: formData.editorContent,
-    }).then(() => {
+    };
+    this.articleService.createArticle(sendData).then(() => {
       this.router.navigateByUrl('/');
       this.snackBar.open('記事を投稿しました', null, {
         duration: 2000,

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { Article } from '../interfaces/article';
 import { Observable } from 'rxjs';
-import { firestore } from 'firebase';
+import { firestore } from 'firebase/app';
 
 @Injectable({
   providedIn: 'root'
@@ -30,5 +30,9 @@ export class ArticleService {
   getArticlesByUId(uId: string): Observable<Article[]> {
     return this.db.collection<Article>(`articles`, ref => ref.where('uId', '==', uId))
       .valueChanges();
+  }
+
+  getArticleByAId(aId: string): Observable<Article> {
+    return this.db.doc<Article>(`articles/${aId}`).valueChanges();
   }
 }

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -1,10 +1,7 @@
 import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { Article } from '../interfaces/article';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
-import { AuthService } from './auth.service';
 
 @Injectable({
   providedIn: 'root'
@@ -12,21 +9,10 @@ import { AuthService } from './auth.service';
 export class ArticleService {
   constructor(
     private db: AngularFirestore,
-    private authService: AuthService,
-    private snackBar: MatSnackBar,
-    private router: Router,
   ) { }
 
-  createArticle(article: Article) {
-    const id = this.db.createId();
-    article.id = id;
-    return this.db.doc(`articles/${id}`).set(article)
-      .then(() => {
-        this.router.navigateByUrl('/');
-        this.snackBar.open('記事を投稿しました', null, {
-          duration: 2000,
-        });
-      });
+  createArticle(article: Article): Promise<void> {
+    return this.db.doc(`articles/${article.aId}`).set(article);
   }
 
   getAllArticles(): Observable<Article[]> {

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { Article } from '../interfaces/article';
 import { Observable } from 'rxjs';
+import { firestore } from 'firebase';
 
 @Injectable({
   providedIn: 'root'
@@ -11,8 +12,15 @@ export class ArticleService {
     private db: AngularFirestore,
   ) { }
 
-  createArticle(article: Article): Promise<void> {
-    return this.db.doc(`articles/${article.aId}`).set(article);
+  createArticle(article: Omit<Article, 'aId' | 'createdAt' | 'updatedAt'>
+  ): Promise<void> {
+    const aId = this.db.createId();
+    return this.db.doc(`articles/${aId}`).set({
+      aId,
+      ...article,
+      createdAt: firestore.Timestamp.now(),
+      updatedAt: firestore.Timestamp.now()
+    });
   }
 
   getAllArticles(): Observable<Article[]> {

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -20,7 +20,7 @@ export class ArticleService {
   }
 
   getArticlesByUId(uId: string): Observable<Article[]> {
-    return this.db.collection<Article>(`articles`, ref => ref.where('userId', '==', uId))
+    return this.db.collection<Article>(`articles`, ref => ref.where('uId', '==', uId))
       .valueChanges();
   }
 }

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -12,11 +12,11 @@ export class ArticleService {
     private db: AngularFirestore,
   ) { }
 
-  createArticle(article: Omit<Article, 'aId' | 'createdAt' | 'updatedAt'>
+  createArticle(article: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt'>
   ): Promise<void> {
-    const aId = this.db.createId();
-    return this.db.doc(`articles/${aId}`).set({
-      aId,
+    const articleId = this.db.createId();
+    return this.db.doc(`articles/${articleId}`).set({
+      articleId,
       ...article,
       createdAt: firestore.Timestamp.now(),
       updatedAt: firestore.Timestamp.now()
@@ -27,12 +27,12 @@ export class ArticleService {
     return this.db.collection<Article>(`articles`).valueChanges();
   }
 
-  getArticlesByUId(uId: string): Observable<Article[]> {
-    return this.db.collection<Article>(`articles`, ref => ref.where('uId', '==', uId))
+  getArticles(uid: string): Observable<Article[]> {
+    return this.db.collection<Article>(`articles`, ref => ref.where('uid', '==', uid))
       .valueChanges();
   }
 
-  getArticleByAId(aId: string): Observable<Article> {
-    return this.db.doc<Article>(`articles/${aId}`).valueChanges();
+  getArticleOnly(articleId: string): Observable<Article> {
+    return this.db.doc<Article>(`articles/${articleId}`).valueChanges();
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -13,11 +13,11 @@ import { switchMap } from 'rxjs/operators';
 })
 export class AuthService {
   afUser$: Observable<User> = this.afAuth.user;
-  uId: string;
+  uid: string;
   user$: Observable<UserData> = this.afAuth.authState.pipe(
     switchMap((afUser) => {
       if (afUser) {
-        return this.userService.getUserByUId(afUser.uid);
+        return this.userService.getUserData(afUser.uid);
       } else {
         return of(null);
       }
@@ -31,7 +31,7 @@ export class AuthService {
     private userService: UserService,
   ) {
     this.afUser$.subscribe(user => {
-      this.uId = user && user.uid;
+      this.uid = user && user.uid;
     });
   }
 
@@ -44,8 +44,8 @@ export class AuthService {
         const userInfoObj = JSON.parse(JSON.stringify(userInfo));
         const avatarURL = userInfoObj.profile_image_url_https.replace('_normal', '');
         this.userService.updateUser({
-          uId: user.uid,
-          uName: userInfoObj.name,
+          uid: user.uid,
+          userName: userInfoObj.name,
           avatarURL,
           screenName: userInfoObj.screen_name,
           description: userInfoObj.description,

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -42,7 +42,7 @@ export class AuthService {
         const user = userCredential.user;
         const userInfo = userCredential.additionalUserInfo.profile;
         const userInfoObj = JSON.parse(JSON.stringify(userInfo));
-        const avatarURL = userInfoObj.profile_image_url.replace('_normal', '');
+        const avatarURL = userInfoObj.profile_image_url_https.replace('_normal', '');
         this.userService.updateUser({
           uId: user.uid,
           uName: userInfoObj.name,

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -3,6 +3,7 @@ import { UserData } from '../interfaces/user';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { AngularFireAuth } from '@angular/fire/auth';
 
 @Injectable({
   providedIn: 'root'
@@ -11,10 +12,11 @@ export class UserService {
 
   constructor(
     private db: AngularFirestore,
+    private afAuth: AngularFireAuth,
   ) { }
 
-  getUserByUId(uId: string): Observable<UserData> {
-    return this.db.doc<UserData>(`users/${uId}`).valueChanges();
+  getUserData(uid: string): Observable<UserData> {
+    return this.db.doc<UserData>(`users/${uid}`).valueChanges();
   }
 
   getUserByScreenName(screenName: string): Observable<UserData> {
@@ -33,10 +35,10 @@ export class UserService {
   }
 
   updateUser(userData: UserData): Promise<void> {
-    return this.db.doc<UserData>(`users/${userData.uId}`).update(userData);
+    return this.db.doc<UserData>(`users/${userData.uid}`).update(userData);
   }
 
-  deleteUser(uId: string): Promise<void> {
-    return this.db.doc<UserData>(`users/${uId}`).delete();
+  async deleteUser(): Promise<void> {
+    return (await this.afAuth.currentUser).delete();
   }
 }

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,7 +1,7 @@
 <div class="card">
-  <a [routerLink]="'/komura_c/n/' + article.uId" class="card__inner">
+  <a [routerLink]="'/komura_c/n/' + article.aId" class="card__inner">
     <img class="card__thumbnail-image" [src]="article.imageURL" alt="サムネイル画像">
-    <h3 class="card__title" (click)="$event.stopPropagation()" [routerLink]="'/komura_c/n/' + article.uId">
+    <h3 class="card__title" (click)="$event.stopPropagation()" [routerLink]="'/komura_c/n/' + article.aId">
       {{ article.title }}
     </h3>
     <div class="card__author">

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,13 +1,18 @@
 <div class="card">
   <a [routerLink]="'/komura_c/n/' + article.uId" class="card__inner">
-    <div class="card__content">
-      <a class="card__title" (click)="$event.stopPropagation()" [routerLink]="'/komura_c/n/' + article.uId">
-        {{ article.title }}
-      </a>
-    </div>
+    <img class="card__thumbnail-image" [src]="article.imageURL" alt="サムネイル画像">
+    <h3 class="card__title" (click)="$event.stopPropagation()" [routerLink]="'/komura_c/n/' + article.uId">
+      {{ article.title }}
+    </h3>
     <div class="card__author">
-      <a class="card__user-icon" (click)="$event.stopPropagation()" [routerLink]="'/komura_c'"></a>
-      <a class="card__user-name" (click)="$event.stopPropagation()" [routerLink]="'/komura_c'">こむら</a>
+      <a (click)="$event.stopPropagation()" [routerLink]="'/'  + article.author.screenName">
+        <img class="card__user-icon" [src]="article.author.avatarURL" alt="ユーザーアイコン"></a>
+      <div class="card__author-name">
+        <a class="card__user-name" (click)="$event.stopPropagation()"
+          [routerLink]="'/' + article.author.screenName">{{article.author.uName}}</a>
+        <a class="card__screen-name" (click)="$event.stopPropagation()"
+          [routerLink]="'/' + article.author.screenName">@{{article.author.screenName}}</a>
+      </div>
     </div>
   </a>
 </div>

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,15 +1,13 @@
-<mat-card class="card">
-  <img mat-card-image class="card__eye-catch" [src]="article.imageURL" alt="アイコン" />
-  <mat-card-content class="card__content">
-    <a class="card__title">
-      {{ article.title }}
-    </a>
-    <p class="card__text">
-      {{ article.text }}
-    </p>
-    <div class="card__author">
-      <a mat-card-avatar class="card__user-icon"></a>
-      <a class="card__user-name">こむら</a>
+<div class="card">
+  <a [routerLink]="'/komura_c/n/' + article.uId" class="card__inner">
+    <div class="card__content">
+      <a class="card__title" (click)="$event.stopPropagation()" [routerLink]="'/komura_c/n/' + article.uId">
+        {{ article.title }}
+      </a>
     </div>
-  </mat-card-content>
-</mat-card>
+    <div class="card__author">
+      <a class="card__user-icon" (click)="$event.stopPropagation()" [routerLink]="'/komura_c'"></a>
+      <a class="card__user-name" (click)="$event.stopPropagation()" [routerLink]="'/komura_c'">こむら</a>
+    </div>
+  </a>
+</div>

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,7 +1,8 @@
 <div class="card">
   <a [routerLink]="'/komura_c/n/' + article.aId" class="card__inner">
     <img class="card__thumbnail-image" [src]="article.imageURL" alt="サムネイル画像">
-    <h3 class="card__title" (click)="$event.stopPropagation()" [routerLink]="'/komura_c/n/' + article.aId">
+    <h3 class="card__title" (click)="$event.stopPropagation(); $event.preventDefault()"
+      [routerLink]="'/komura_c/n/' + article.aId">
       {{ article.title }}
     </h3>
     <div class="card__author">

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,8 +1,8 @@
 <div class="card">
-  <a [routerLink]="'/komura_c/n/' + article.aId" class="card__inner">
+  <a [routerLink]="'/komura_c/n/' + article.articleId" class="card__inner">
     <img class="card__thumbnail-image" [src]="article.imageURL" alt="サムネイル画像">
     <h3 class="card__title" (click)="$event.stopPropagation(); $event.preventDefault()"
-      [routerLink]="'/komura_c/n/' + article.aId">
+      [routerLink]="'/komura_c/n/' + article.articleId">
       {{ article.title }}
     </h3>
     <div class="card__author">
@@ -10,7 +10,7 @@
         <img class="card__user-icon" [src]="article.author.avatarURL" alt="ユーザーアイコン"></a>
       <div class="card__author-name">
         <a class="card__user-name" (click)="$event.stopPropagation()"
-          [routerLink]="'/' + article.author.screenName">{{article.author.uName}}</a>
+          [routerLink]="'/' + article.author.screenName">{{article.author.userName}}</a>
         <a class="card__screen-name" (click)="$event.stopPropagation()"
           [routerLink]="'/' + article.author.screenName">@{{article.author.screenName}}</a>
       </div>

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,5 +1,5 @@
 <mat-card class="card">
-  <img mat-card-image class="card__eye-catch" [src]="article.thumbnailUrl" alt="アイコン" />
+  <img mat-card-image class="card__eye-catch" [src]="article.imageURL" alt="アイコン" />
   <mat-card-content class="card__content">
     <a class="card__title">
       {{ article.title }}

--- a/src/app/shared/article/article.component.scss
+++ b/src/app/shared/article/article.component.scss
@@ -1,10 +1,14 @@
 .card {
   max-width: 610px;
-  padding: 16px 0 0 0;
-  margin-bottom: 30px;
-  &__eye-catch {
-    max-height: 300px;
-    margin: 0;
+  border: solid 1px #e0e0e0;
+  border-radius: 4px;
+  background-color: #ffffff;
+  display: block;
+  position: relative;
+  &__inner {
+    display: block;
+    outline-style: none;
+    cursor: pointer;
   }
   &__content {
     padding: 16px;
@@ -19,12 +23,13 @@
     flex-wrap: wrap;
     align-items: center;
   }
-  &__user-icon {
-    background-image: url("https://pbs.twimg.com/profile_images/1020302875229007872/nvfnS9YM_normal.jpg");
-    background-size: cover;
-  }
   &__user-name {
     font-size: 16px;
     padding: 8px;
   }
+}
+
+.card:hover {
+  transition-duration: 0.4s;
+  background-color: #e7e7e7;
 }

--- a/src/app/shared/article/article.component.scss
+++ b/src/app/shared/article/article.component.scss
@@ -3,7 +3,7 @@
   border: solid 1px #e0e0e0;
   border-radius: 4px;
   background-color: #ffffff;
-  :hover {
+  &:hover {
     transition-duration: 0.2s;
     background-color: #f5f5f5;
   }
@@ -21,6 +21,9 @@
     font-size: 20px;
     font-weight: bold;
     cursor: pointer;
+    &:hover {
+      text-decoration: underline;
+    }
   }
   &__author {
     display: flex;
@@ -37,22 +40,12 @@
     display: flex;
     flex-direction: column;
     padding: 8px;
-    :hover {
-      text-decoration: underline;
-    }
   }
   &__user-name {
     font-weight: bold;
     font-size: 16px;
-    :hover {
-      text-decoration: underline;
-    }
   }
   &__screen-name {
     padding-left: 4px;
   }
-}
-
-h3.card__title:hover {
-  text-decoration: underline;
 }

--- a/src/app/shared/article/article.component.scss
+++ b/src/app/shared/article/article.component.scss
@@ -5,7 +5,7 @@
   background-color: #ffffff;
   :hover {
     transition-duration: 0.2s;
-    background-color: #e7e7e7;
+    background-color: #f5f5f5;
   }
   &__inner {
     padding: 20px;
@@ -28,7 +28,9 @@
     align-items: center;
   }
   &__user-icon {
+    display: block;
     width: 40px;
+    height: 40px;
     border-radius: 50%;
   }
   &__author-name {

--- a/src/app/shared/article/article.component.scss
+++ b/src/app/shared/article/article.component.scss
@@ -3,33 +3,54 @@
   border: solid 1px #e0e0e0;
   border-radius: 4px;
   background-color: #ffffff;
-  display: block;
-  position: relative;
+  :hover {
+    transition-duration: 0.2s;
+    background-color: #e7e7e7;
+  }
   &__inner {
+    padding: 20px;
     display: block;
     outline-style: none;
-    cursor: pointer;
+    text-decoration: none;
   }
-  &__content {
-    padding: 16px;
+  &__thumbnail-image {
+    border-radius: 4px;
   }
   &__title {
+    margin: 8px 0;
     font-size: 20px;
     font-weight: bold;
+    cursor: pointer;
   }
   &__author {
-    margin: 0;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
   }
-  &__user-name {
-    font-size: 16px;
+  &__user-icon {
+    width: 40px;
+    border-radius: 50%;
+  }
+  &__author-name {
+    display: flex;
+    flex-direction: column;
     padding: 8px;
+    :hover {
+      text-decoration: underline;
+    }
+  }
+  &__user-name {
+    font-weight: bold;
+    font-size: 16px;
+    :hover {
+      text-decoration: underline;
+    }
+  }
+  &__screen-name {
+    padding-left: 4px;
   }
 }
 
-.card:hover {
-  transition-duration: 0.4s;
-  background-color: #e7e7e7;
+h3.card__title:hover {
+  text-decoration: underline;
 }

--- a/src/app/shared/article/article.component.ts
+++ b/src/app/shared/article/article.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { Article } from 'src/app/interfaces/article';
+import { ArticleWithAuthor } from 'src/app/interfaces/article';
 
 @Component({
   selector: 'app-article',
@@ -7,7 +7,7 @@ import { Article } from 'src/app/interfaces/article';
   styleUrls: ['./article.component.scss'],
 })
 export class ArticleComponent implements OnInit {
-  @Input() article: Article;
+  @Input() article: ArticleWithAuthor;
 
   constructor() { }
 

--- a/src/app/shared/shared-routing.module.ts
+++ b/src/app/shared/shared-routing.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+const routes: Routes = [];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class SharedRoutingModule { }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,12 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { SharedRoutingModule } from './shared-routing.module';
+
 import { ArticleComponent } from './article/article.component';
-import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [ArticleComponent],
-  imports: [CommonModule, MatCardModule, MatButtonModule],
+  imports: [CommonModule, SharedRoutingModule, MatButtonModule],
   exports: [ArticleComponent],
 })
 export class SharedModule { }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,7 +21,7 @@ img {
 }
 .container {
   padding: 76px 16px 16px 16px;
-  background-color: #f5f5f5;
+  background-color: #ffffff;
 }
 
 @media screen and (max-width: 480px) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -13,6 +13,9 @@ a {
   text-decoration: none;
   cursor: pointer;
 }
+a:hover {
+  text-decoration: underline;
+}
 img {
   max-width: 100%;
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -12,9 +12,9 @@ a {
   color: inherit;
   text-decoration: none;
   cursor: pointer;
-}
-a:hover {
-  text-decoration: underline;
+  &:hover {
+    text-decoration: underline;
+  }
 }
 img {
   max-width: 100%;


### PR DESCRIPTION
fix #17 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ

![feature:17](https://user-images.githubusercontent.com/37304826/86509186-0678ce00-be21-11ea-876d-d2550c8b6d08.gif)

### 記事コンポーネント
- articleコンポーネントのマークアップ、スタイル調整
- article.component.htmlでrouterLinkを使おうとしたところ使えなかったのでshared-routing.moduleを追加
- 記事をクリックするとマイページ、記事詳細画面に行くように実装

### 各コンポーネントのts
- ArticleWithAuthor型を作成、home.component.ts, mypage.component.ts, note.component.tsで取得できるようにRxjs記述
- 記事詳細画面に記事データを表示(note-headerのみ)

### 記事作成画面
- create.component.scssに記述した::ng-deepが他コンポーネントのcssに影響出たので削除、プレビューのスタイル調整

### Firebase
- Firestore backendでエラー(Could not reach Cloud Firestore backend. Backend didn't respond within 10 seconds.)が出たため、npm i firebase --saveでfirebaseアップデート

### 微細な変更
- twitterのavatarURLをhttpsで大きい画像を取得
