### PR TITLE
Froala Editorの導入、画像アップロード、離脱ガードの設定、公開設定 #45

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/angular.json
+++ b/angular.json
@@ -26,7 +26,9 @@
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": [
               "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.scss"
+              "src/styles.scss",
+              "./node_modules/froala-editor/css/froala_editor.pkgd.min.css",
+              "./node_modules/froala-editor/css/froala_style.min.css"
             ],
             "scripts": []
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3242,14 +3242,6 @@
         }
       }
     },
-    "@kolkov/angular-editor": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@kolkov/angular-editor/-/angular-editor-1.1.2.tgz",
-      "integrity": "sha512-ae6v4XDLxIZhHyMAWma4QZvGIDvsn7eeqE+sQIm+9VbXn2jWaS3Mqg4nnKbZSB7p0xhbWviKG2Frb1I8s+ne0Q==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "@ngtools/webpack": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-9.1.7.tgz",
@@ -3791,6 +3783,14 @@
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
+    },
+    "angular-froala-wysiwyg": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/angular-froala-wysiwyg/-/angular-froala-wysiwyg-3.1.0.tgz",
+      "integrity": "sha512-XV+8dlEc2TzR4glY3ygTFPdOzLgxB7HqolpA8KbOhmz6eAu1a6b45JQfQtQQyl6XGTf1PxT1j9cz9dvq8u+GKw==",
+      "requires": {
+        "froala-editor": "^3.1.0"
+      }
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -8061,6 +8061,11 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
+    },
+    "froala-editor": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/froala-editor/-/froala-editor-3.1.1.tgz",
+      "integrity": "sha512-1VYBEL5QN92Qmlvc1tgL6Ij55hMDXnkStv1c/MoNwdkTdK81W1JYmS4LaLFfUmva1Zvp5DWEM+G3G8+VyfvDEQ=="
     },
     "from2": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "^9.1.9",
     "@angular/platform-browser-dynamic": "^9.1.9",
     "@angular/router": "^9.1.9",
-    "@kolkov/angular-editor": "^1.1.2",
+    "angular-froala-wysiwyg": "^3.1.0",
     "firebase": "^7.15.5",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",

--- a/src/app/about/about/about.component.ts
+++ b/src/app/about/about/about.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from 'src/app/services/auth.service';
-import { UserService } from 'src/app/services/user.service';
 import { Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
@@ -14,7 +13,6 @@ export class AboutComponent implements OnInit {
 
   constructor(
     private authService: AuthService,
-    private userService: UserService,
     private router: Router,
     private snackBar: MatSnackBar,
   ) { }
@@ -27,7 +25,6 @@ export class AboutComponent implements OnInit {
       this.isProcessing = true;
       this.authService.login().finally(() => {
         this.isProcessing = false;
-        this.userService.getUserByUId(this.authService.uId);
       });
     } else {
       this.router.navigateByUrl('/');

--- a/src/app/about/about/about.component.ts
+++ b/src/app/about/about/about.component.ts
@@ -28,7 +28,7 @@ export class AboutComponent implements OnInit {
       });
     } else {
       this.router.navigateByUrl('/');
-      this.snackBar.open('すでにログインしています', null, { duration: 2000 });
+      this.snackBar.open('すでにログインしています。', '閉じる', { duration: 5000 });
     }
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -21,6 +21,9 @@ const routes: Routes = [
   },
   {
     path: 'notes',
+    data: {
+      isNotShowFooter: true,
+    },
     loadChildren: () =>
       import('./notes/notes.module').then((m) => m.NotesModule),
     canLoad: [AuthGuard],

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,4 +2,6 @@
 <div class="container">
   <router-outlet></router-outlet>
 </div>
-<app-footer></app-footer>
+<ng-container *ngIf="activatedRouteData | async as data">
+  <app-footer *ngIf="!data.isNotShowFooter"></app-footer>
+</ng-container>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,6 @@
 import { Component } from '@angular/core';
+import { Router, NavigationEnd, ActivatedRoute, Data } from '@angular/router';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -7,4 +9,13 @@ import { Component } from '@angular/core';
 })
 export class AppComponent {
   title = 'dtmplace';
+  activatedRouteData: Observable<Data>;
+
+  constructor(private router: Router, private activatedRoute: ActivatedRoute) {
+    this.router.events.subscribe(event => {
+      if ((event instanceof NavigationEnd)) {
+        this.activatedRouteData = this.activatedRoute.firstChild.data;
+      }
+    });
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,7 +18,7 @@ import { AngularFireStorageModule } from '@angular/fire/storage';
 import { AngularFireFunctionsModule, REGION } from '@angular/fire/functions';
 import { AngularFireAuthModule } from '@angular/fire/auth';
 import { environment } from '../environments/environment';
-import { HttpClientModule } from '@angular/common/http';
+import { FroalaEditorModule, FroalaViewModule } from 'angular-froala-wysiwyg';
 
 @NgModule({
   declarations: [AppComponent, HeaderComponent, FooterComponent, NotFoundComponent],
@@ -37,7 +37,8 @@ import { HttpClientModule } from '@angular/common/http';
     AngularFireStorageModule,
     AngularFireFunctionsModule,
     AngularFireAuthModule,
-    HttpClientModule,
+    FroalaEditorModule.forRoot(),
+    FroalaViewModule.forRoot(),
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/guards/form.guard.spec.ts
+++ b/src/app/guards/form.guard.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FormGuard } from './form.guard';
+
+describe('FormGuard', () => {
+  let guard: FormGuard;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    guard = TestBed.inject(FormGuard);
+  });
+
+  it('should be created', () => {
+    expect(guard).toBeTruthy();
+  });
+});

--- a/src/app/guards/form.guard.ts
+++ b/src/app/guards/form.guard.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { CanDeactivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { Observable, of } from 'rxjs';
+import { CreateComponent } from '../notes/create/create.component';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class FormGuard implements CanDeactivate<unknown> {
+  canDeactivate(
+    component: CreateComponent,
+    currentRoute: ActivatedRouteSnapshot,
+    currentState: RouterStateSnapshot,
+    nextState?: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    if (component.form.pristine || component.isComplete) {
+      return true;
+    }
+    const confirmation = window.confirm('作業中の内容が失われますがよろしいですか？');
+    return of(confirmation);
+  }
+}

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -1,7 +1,7 @@
 .header {
   background-color: #ffffff;
   position: fixed;
-  z-index: 10;
+  z-index: 100;
   margin: 0;
   display: flex;
   height: 70px;

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -4,7 +4,7 @@ import { firestore } from 'firebase/app';
 export interface Article {
   articleId: string;
   uid: string;
-  imageURL: string;
+  thumbnailURL: string;
   title: string;
   tag: string;
   text: string;

--- a/src/app/interfaces/article.ts
+++ b/src/app/interfaces/article.ts
@@ -8,6 +8,7 @@ export interface Article {
   title: string;
   tag: string;
   text: string;
+  isPublic: boolean;
   createdAt: firestore.Timestamp;
   updatedAt: firestore.Timestamp;
 }

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -22,7 +22,7 @@ export class MypageComponent implements OnInit {
     private userService: UserService,
     private articleService: ArticleService,
   ) {
-    route.paramMap.subscribe(params => {
+    this.route.paramMap.subscribe(params => {
       this.screenName = params.get('id');
       this.user$ = this.userService.getUserByScreenName(
         this.screenName

--- a/src/app/mypage/note/note.component.ts
+++ b/src/app/mypage/note/note.component.ts
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { UserService } from 'src/app/services/user.service';
 import { UserData } from 'src/app/interfaces/user';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-note',
@@ -20,8 +21,9 @@ export class NoteComponent implements OnInit {
     private route: ActivatedRoute,
     private articleService: ArticleService,
     private userService: UserService,
+    private authService: AuthService,
   ) {
-    route.paramMap.subscribe(params => {
+    this.route.paramMap.subscribe(params => {
       this.articleId = params.get('id');
       const post$ = this.articleService.getArticleOnly(this.articleId);
       let articleData: Article;
@@ -38,7 +40,11 @@ export class NoteComponent implements OnInit {
             ...articleData,
             author,
           };
-          return result;
+          if ((articleData.isPublic === true) || (this.authService.uid === author.uid)) {
+            return result;
+          } else {
+            return null;
+          }
         })
       );
     });

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -1,5 +1,5 @@
 <div class="editor">
-  <form class="editor__form" [formGroup]="form" [style.fontSize.px]="16">
+  <form class="editor__form" [formGroup]="form">
     <div class="editor__header">
       <mat-form-field class="editor__title" floatLabel="always">
         <mat-label></mat-label>

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -1,4 +1,4 @@
-<mat-card class="editor">
+<div class="editor">
   <form class="editor__form" [formGroup]="form">
     <div class="editor__header">
       <mat-form-field class="editor__title" floatLabel="always">
@@ -14,10 +14,15 @@
     </div>
     <div class="editor__body">
       <div class="editor__content">
-        <angular-editor formControlName="editorContent" class="editor__main" [config]="editorConfig">
+        <angular-editor formControlName="editorContent" [config]="editorConfig">
         </angular-editor>
       </div>
-      <div class="editor__preview" [innerHTML]='editorPreview'></div>
+      <div class="editor__preview">
+        <div class="preview__header">
+          <div class="preview__title">プレビュー</div>
+        </div>
+        <div class="preview__main" [innerHTML]='editorPreview'></div>
+      </div>
     </div>
     <div class="editor__buttons">
       <button [disabled]="form.invalid" class="draft" mat-flat-button color="primary">
@@ -28,4 +33,4 @@
       </button>
     </div>
   </form>
-</mat-card>
+</div>

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -14,14 +14,13 @@
     </div>
     <div class="editor__body">
       <div class="editor__content">
-        <angular-editor formControlName="editorContent" [config]="editorConfig">
-        </angular-editor>
+        <div [froalaEditor]="options" formControlName="editorContent" [(froalaModel)]="editorPreview"></div>
       </div>
       <div class="editor__preview">
         <div class="preview__header">
           <div class="preview__title">プレビュー</div>
         </div>
-        <div class="preview__main" [innerHTML]='editorPreview'></div>
+        <div class="preview__main" [froalaView]="editorPreview"></div>
       </div>
     </div>
     <div class="editor__buttons">

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -1,27 +1,19 @@
 <div class="editor">
-  <form class="editor__form" [formGroup]="form">
+  <form class="editor__form" [formGroup]="form" [style.fontSize.px]="16">
     <div class="editor__header">
       <mat-form-field class="editor__title" floatLabel="always">
         <mat-label></mat-label>
-        <input type="text" formControlName="title" matInput placeholder="タイトル（80文字以内）*" autocomplete="off" />
-        <mat-error *ngIf="titleControl.hasError('required')">必須入力です</mat-error>
-        <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは80文字以内にしてください</mat-error>
+        <input type="text" formControlName="title" matInput placeholder="タイトル*" autocomplete="off" />
+        <mat-error *ngIf="titleControl.hasError('required')">必須項目です</mat-error>
+        <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは255文字以内にしてください</mat-error>
       </mat-form-field>
       <mat-form-field class="editor__tag" floatLabel="always">
         <mat-label></mat-label>
-        <input type="text" formControlName="tag" matInput placeholder="作曲やDTMに関するタグを入力" autocomplete="off" />
+        <input type="text" formControlName="tag" matInput placeholder="タグ" autocomplete="off" />
       </mat-form-field>
     </div>
-    <div class="editor__body">
-      <div class="editor__content">
-        <div id="froalaEditor" [froalaEditor]="options" formControlName="editorContent" [(froalaModel)]="editorPreview">
-        </div>
-      </div>
-      <div class="editor__preview">
-        <div class="preview__header">
-          <div class="preview__title">プレビュー</div>
-        </div>
-        <div class="preview__main" [froalaView]="editorPreview"></div>
+    <div class="editor__content">
+      <div [froalaEditor]="options" formControlName="editorContent">
       </div>
     </div>
     <div class="editor__buttons">

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -14,7 +14,8 @@
     </div>
     <div class="editor__body">
       <div class="editor__content">
-        <div [froalaEditor]="options" formControlName="editorContent" [(froalaModel)]="editorPreview"></div>
+        <div id="froalaEditor" [froalaEditor]="options" formControlName="editorContent" [(froalaModel)]="editorPreview">
+        </div>
       </div>
       <div class="editor__preview">
         <div class="preview__header">

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -17,12 +17,13 @@
       </div>
     </div>
     <div class="editor__buttons">
-      <button [disabled]="form.invalid || form.pristine" class="draft" mat-flat-button color="primary">
-        下書きに保存
+      <mat-slide-toggle class="public-option" formControlName="isPublic">公開設定</mat-slide-toggle>
+      <button class="cancel-button" mat-button (click)="cancel()">
+        キャンセル
       </button>
-      <button [disabled]="form.invalid || form.pristine" class="post" mat-flat-button color="primary"
+      <button [disabled]="form.invalid || form.pristine" class="post-button" mat-flat-button color="primary"
         (click)="submit()">
-        記事を公開する
+        {{isPublicControl.value ? '記事を公開' : '下書き保存'}}
       </button>
     </div>
   </form>

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -17,10 +17,11 @@
       </div>
     </div>
     <div class="editor__buttons">
-      <button [disabled]="form.invalid" class="draft" mat-flat-button color="primary">
+      <button [disabled]="form.invalid || form.pristine" class="draft" mat-flat-button color="primary">
         下書きに保存
       </button>
-      <button [disabled]="form.invalid" class="post" mat-flat-button color="primary" (click)="submit()">
+      <button [disabled]="form.invalid || form.pristine" class="post" mat-flat-button color="primary"
+        (click)="submit()">
         記事を公開する
       </button>
     </div>

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -1,6 +1,6 @@
 .editor {
-  margin: -16px 0;
-  background-color: #ffffff;
+  max-width: 800px;
+  margin: -10px auto;
   &__form {
     width: 100%;
   }
@@ -9,30 +9,18 @@
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    padding: 12px 0;
+    align-items: center;
+    padding: 8px 0;
   }
   &__title {
     width: 48%;
-    min-width: 300px;
-    margin-right: 24px;
+    padding-right: 18px;
   }
   &__tag {
     width: 48%;
-    min-width: 300px;
-  }
-  &__body {
-    width: 100%;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
   }
   &__content {
     width: 100%;
-    max-width: 100%;
-  }
-  &__preview {
-    width: 98%;
-    border: 1px solid #ddd;
-    border-radius: 8px;
   }
   &__buttons {
     width: 100%;
@@ -49,31 +37,19 @@ button {
   padding: 8px 32px;
   margin: 8px;
 }
-.preview {
-  &__header {
-    line-height: 40px;
-    padding: 4px;
-    border-bottom: 1px solid #ddd;
-  }
-  &__title {
-    font-size: 16px;
-    color: #92989e;
-    padding-left: 10px;
-  }
-  &__main {
-    padding: 20px;
-    max-height: 370px;
-    overflow-y: scroll;
-  }
+
+.input-thumbnail {
+  display: none;
 }
 
-@media screen and (max-width: 480px) {
+@media screen and (max-width: 612px) {
   .editor {
-    &__body {
-      display: block;
+    &__title {
+      width: 100%;
+      padding-right: 0;
     }
-    &__preview {
-      display: none;
+    &__tag {
+      width: 100%;
     }
   }
 }

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -31,6 +31,7 @@
   &__preview {
     width: 98%;
     border: 1px solid #ddd;
+    border-radius: 8px;
   }
   &__buttons {
     width: 100%;
@@ -50,11 +51,9 @@ button {
 }
 .preview {
   &__header {
-    background-color: #f5f5f5;
-    line-height: 32px;
+    line-height: 40px;
     padding: 4px;
-    border: 1px solid #ddd;
-    background-color: #f5f5f5;
+    border-bottom: 1px solid #ddd;
   }
   &__title {
     font-size: 16px;
@@ -62,7 +61,7 @@ button {
     padding-left: 10px;
   }
   &__main {
-    padding: 0.5rem 0.8rem 1rem;
+    padding: 20px;
     max-height: 370px;
     overflow-y: scroll;
   }

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -27,6 +27,7 @@
   }
   &__content {
     width: 100%;
+    max-width: 100%;
   }
   &__preview {
     width: 98%;
@@ -45,7 +46,6 @@
   background-color: grey;
 }
 button {
-  max-width: 440px;
   padding: 8px 32px;
   margin: 8px;
 }
@@ -64,5 +64,16 @@ button {
     padding: 20px;
     max-height: 370px;
     overflow-y: scroll;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  .editor {
+    &__body {
+      display: block;
+    }
+    &__preview {
+      display: none;
+    }
   }
 }

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -1,5 +1,5 @@
 .editor {
-  margin: -16px -16px -16px -16px;
+  margin: -16px 0;
   background-color: #ffffff;
   &__form {
     width: 100%;
@@ -30,9 +30,8 @@
   }
   &__preview {
     width: 95%;
+    height: 100%;
     border: 1px solid #ddd;
-    padding: 12px;
-    background-color: #f5f5f5;
     overflow-y: scroll;
   }
   &__buttons {
@@ -50,4 +49,21 @@ button {
   max-width: 440px;
   padding: 8px 32px;
   margin: 8px;
+}
+.preview {
+  &__header {
+    background-color: #f5f5f5;
+    line-height: 32px;
+    padding: 4px;
+    border: 1px solid #ddd;
+    background-color: #f5f5f5;
+  }
+  &__title {
+    font-size: 16px;
+    color: #92989e;
+    padding-left: 10px;
+  }
+  &__main {
+    padding: 0.5rem 0.8rem 1rem;
+  }
 }

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -29,10 +29,8 @@
     width: 100%;
   }
   &__preview {
-    width: 95%;
-    height: 100%;
+    width: 98%;
     border: 1px solid #ddd;
-    overflow-y: scroll;
   }
   &__buttons {
     width: 100%;
@@ -65,5 +63,7 @@ button {
   }
   &__main {
     padding: 0.5rem 0.8rem 1rem;
+    max-height: 370px;
+    overflow-y: scroll;
   }
 }

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -26,14 +26,20 @@
     width: 100%;
     display: flex;
     flex-direction: row;
+    align-items: center;
     flex-wrap: wrap;
     justify-content: flex-end;
   }
 }
-.draft {
-  background-color: grey;
+.public-option {
+  font-weight: bold;
+}
+.post-button {
+  background-color: #ff5500;
 }
 button {
+  font-size: 16px;
+  font-weight: bold;
   padding: 8px 32px;
   margin: 8px;
 }

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -44,19 +44,19 @@ export class CreateComponent implements OnInit {
     enableToolbar: true,
     showToolbar: true,
     placeholder: '作曲やDTMに関する知識を共有しよう',
-    defaultParagraphSeparator: 'p',
     sanitize: true,
     toolbarPosition: 'top',
     toolbarHiddenButtons: [
-      ['subscript',
+      ['undo',
+        'redo', 'subscript',
         'superscript', 'justifyLeft',
         'justifyCenter',
         'justifyRight',
         'justifyFull', 'indent',
         'outdent', 'fontName'],
       ['fontSize', 'textColor',
-        'backgroundColor', 'customClasses',
-        'insertImage',
+        'customClasses',
+        'backgroundColor',
         'insertVideo', 'insertHorizontalRule',
         'toggleEditorMode']
     ]

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -9,7 +9,6 @@ import 'froala-editor/js/plugins/char_counter.min.js';
 import 'froala-editor/js/plugins/colors.min.js';
 import 'froala-editor/js/plugins/draggable.min.js';
 import 'froala-editor/js/plugins/emoticons.min.js';
-import 'froala-editor/js/plugins/file.min.js';
 import 'froala-editor/js/plugins/font_size.min.js';
 import 'froala-editor/js/plugins/fullscreen.min.js';
 import 'froala-editor/js/plugins/image.min.js';
@@ -70,7 +69,7 @@ export class CreateComponent implements OnInit {
         buttons: ['formatOL', 'formatUL', 'paragraphFormat', 'paragraphStyle', 'quote']
       },
       moreRich: {
-        buttons: ['insertLink', 'insertImage', 'insertVideo', 'insertTable', 'emoticons', 'specialCharacters', 'insertFile']
+        buttons: ['insertLink', 'insertImage', 'insertVideo', 'insertTable', 'emoticons', 'specialCharacters']
       },
       moreMisc: {
         buttons: ['undo', 'redo', 'fullscreen']
@@ -84,11 +83,24 @@ export class CreateComponent implements OnInit {
       },
       'image.beforeUpload': (images) => {
         const file = images[0];
+        const fileSizeLimit = 2000000;
         const uid = this.authService.uid;
-        const downloadURLPromise = this.articleService.uploadImage(uid, file);
-        downloadURLPromise.then((downloadURL) => {
-          this.froalaEditor._editor.image.insert(downloadURL, null, null, this.froalaEditor._editor.image.get());
-        });
+        if ((file.size < fileSizeLimit)) {
+          const downloadURLPromise = this.articleService.uploadImage(uid, file);
+          downloadURLPromise.then((downloadURL) => {
+            this.froalaEditor._editor.image.insert(downloadURL, null, null, this.froalaEditor._editor.image.get());
+          });
+          return null;
+        } else {
+          const msg = 'ファイルサイズは2MB以内にしてください';
+          this.snackBar.open(msg, '閉じる');
+          return false;
+        }
+      },
+      'video.beforeUpload': () => {
+        const msg = 'すみません…動画はアップロードできません…';
+        this.snackBar.open(msg, '閉じる');
+        return false;
       },
     }
   };
@@ -106,7 +118,6 @@ export class CreateComponent implements OnInit {
 
   submit() {
     const formData = this.form.value;
-    console.log(formData);
     const sendData: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt'>
       = {
       uid: this.authService.uid,

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -2,10 +2,33 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { ArticleService } from 'src/app/services/article.service';
 import { AuthService } from 'src/app/services/auth.service';
-import { AngularEditorConfig } from '@kolkov/angular-editor';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { Article } from 'src/app/interfaces/article';
+import 'froala-editor/js/plugins/char_counter.min.js';
+import 'froala-editor/js/plugins/colors.min.js';
+import 'froala-editor/js/plugins/code_beautifier.min.js';
+import 'froala-editor/js/plugins/code_view.min.js';
+import 'froala-editor/js/plugins/draggable.min.js';
+import 'froala-editor/js/plugins/emoticons.min.js';
+import 'froala-editor/js/plugins/file.min.js';
+import 'froala-editor/js/plugins/font_size.min.js';
+import 'froala-editor/js/plugins/fullscreen.min.js';
+import 'froala-editor/js/plugins/image.min.js';
+import 'froala-editor/js/plugins/image_manager.min.js';
+import 'froala-editor/js/third_party/image_tui.min.js';
+import 'froala-editor/js/plugins/line_breaker.min.js';
+import 'froala-editor/js/plugins/link.min.js';
+import 'froala-editor/js/plugins/lists.min.js';
+import 'froala-editor/js/plugins/help.min.js';
+import 'froala-editor/js/plugins/paragraph_style.min.js';
+import 'froala-editor/js/plugins/paragraph_format.min.js';
+import 'froala-editor/js/plugins/quick_insert.min.js';
+import 'froala-editor/js/plugins/quote.min.js';
+import 'froala-editor/js/plugins/table.min.js';
+import 'froala-editor/js/plugins/url.min.js';
+import 'froala-editor/js/plugins/video.min.js';
+import 'froala-editor/js/languages/ja.js';
 
 @Component({
   selector: 'app-create',
@@ -18,7 +41,7 @@ export class CreateComponent implements OnInit {
     tag: [''],
     editorContent: [''],
   });
-  editorPreview: string;
+  editorPreview = '';
 
   get titleControl() {
     return this.form.get('title') as FormControl;
@@ -32,34 +55,29 @@ export class CreateComponent implements OnInit {
     return this.form.get('editorContent') as FormControl;
   }
 
-  editorConfig: AngularEditorConfig = {
-    editable: true,
-    spellcheck: true,
-    height: '350px',
-    minHeight: '350px',
-    maxHeight: '350px',
-    width: 'auto',
-    minWidth: '0',
-    translate: 'yes',
-    enableToolbar: true,
-    showToolbar: true,
-    placeholder: '作曲やDTMに関する知識を共有しよう',
-    sanitize: true,
-    toolbarPosition: 'top',
-    toolbarHiddenButtons: [
-      ['undo',
-        'redo', 'subscript',
-        'superscript', 'justifyLeft',
-        'justifyCenter',
-        'justifyRight',
-        'justifyFull', 'indent',
-        'outdent', 'fontName'],
-      ['fontSize', 'textColor',
-        'customClasses',
-        'backgroundColor',
-        'insertVideo', 'insertHorizontalRule',
-        'toggleEditorMode']
-    ]
+  public options = {
+    toolbarSticky: false,
+    toolbarInline: false,
+    height: 350,
+    placeholderText: '作曲やDTMに関する知識を共有しよう',
+    charCounterCount: true,
+    language: 'ja',
+    toolbarButtons: [['bold', 'italic', 'underline', 'strikeThrough', 'textColor', 'clearFormatting'], ['formatOL', 'formatUL', 'paragraphFormat', 'paragraphStyle', 'quote'], ['insertLink', 'insertImage', 'insertVideo', 'insertTable', 'emoticons', 'specialCharacters', 'embedly', 'insertFile'], ['undo', 'redo', 'fullscreen', 'help']]
+    ,
+    toolbarButtonsXS: {
+      moreText: {
+        buttons: ['bold', 'italic', 'underline', 'strikeThrough', 'textColor', 'clearFormatting']
+      },
+      moreParagraph: {
+        buttons: ['formatOL', 'formatUL', 'paragraphFormat', 'paragraphStyle', 'quote']
+      },
+      moreRich: {
+        buttons: ['insertLink', 'insertImage', 'insertVideo', 'insertTable', 'emoticons', 'specialCharacters', 'embedly', 'insertFile']
+      },
+      moreMisc: {
+        buttons: ['undo', 'redo', 'fullscreen', 'help']
+      }
+    }
   };
 
   constructor(
@@ -70,11 +88,7 @@ export class CreateComponent implements OnInit {
     private router: Router,
   ) { }
 
-  ngOnInit(): void {
-    this.form.valueChanges.subscribe((inputText) => {
-      this.editorPreview = inputText.editorContent;
-    });
-  }
+  ngOnInit(): void { }
 
   submit() {
     const formData = this.form.value;

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -125,7 +125,7 @@ export class CreateComponent implements OnInit {
         } else {
           const msg = '３メガバイト未満の画像を利用してください';
           this.ngZone.run(() => {
-            this.snackBar.open(msg, '閉じる');
+            this.snackBar.open(msg, '閉じる', { duration: 5000 });
           });
           return false;
         }
@@ -181,13 +181,16 @@ export class CreateComponent implements OnInit {
       text: formData.editorContent,
       isPublic: formData.isPublic
     };
-    const msg = '記事を投稿しました！';
     this.isComplete = true;
+    let msg: string;
+    if (formData.isPublic) {
+      msg = '記事を投稿しました！おめでとうございます。';
+    } else {
+      msg = '下書きを保存しました！おつかれさまです。';
+    }
     this.articleService.createArticle(sendData).then(() => {
       this.router.navigateByUrl('/');
-      this.snackBar.open(msg, null, {
-        duration: 2000,
-      });
+      this.snackBar.open(msg, '閉じる', { duration: 5000 });
     });
   }
 }

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { ArticleService } from 'src/app/services/article.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Router, ActivatedRoute } from '@angular/router';
+import { Router } from '@angular/router';
 import { Article } from 'src/app/interfaces/article';
 import 'froala-editor/js/plugins/char_counter.min.js';
 import 'froala-editor/js/plugins/colors.min.js';

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -5,6 +5,8 @@ import { AuthService } from 'src/app/services/auth.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 import { Article } from 'src/app/interfaces/article';
+import { Location } from '@angular/common';
+
 import 'froala-editor/js/plugins/char_counter.min.js';
 import 'froala-editor/js/plugins/colors.min.js';
 import 'froala-editor/js/plugins/draggable.min.js';
@@ -37,6 +39,7 @@ export class CreateComponent implements OnInit {
     title: ['', [Validators.required, Validators.maxLength(255)]],
     tag: [''],
     editorContent: [''],
+    isPublic: [true],
   });
   froalaEditor;
   isComplete: boolean;
@@ -51,6 +54,10 @@ export class CreateComponent implements OnInit {
 
   get editorContentControl() {
     return this.form.get('editorContent') as FormControl;
+  }
+
+  get isPublicControl() {
+    return this.form.get('isPublic') as FormControl;
   }
 
   public options = {
@@ -133,6 +140,7 @@ export class CreateComponent implements OnInit {
     private snackBar: MatSnackBar,
     private router: Router,
     private ngZone: NgZone,
+    private location: Location,
   ) { }
 
   ngOnInit(): void { }
@@ -141,8 +149,12 @@ export class CreateComponent implements OnInit {
   unloadNotification($event: any) {
     if (this.form.dirty) {
       $event.preventDefault();
-      $event.returnValue = '作業中の内容が失われますがよろしいですか？';
+      $event.returnValue = '作業中の内容が失われますが、よろしいですか？';
     }
+  }
+
+  cancel() {
+    this.location.back();
   }
 
   getFirstImageURL(html: string): string {
@@ -167,11 +179,13 @@ export class CreateComponent implements OnInit {
       title: formData.title,
       tag: 'DTM',
       text: formData.editorContent,
+      isPublic: formData.isPublic
     };
+    const msg = '記事を投稿しました！';
     this.isComplete = true;
     this.articleService.createArticle(sendData).then(() => {
       this.router.navigateByUrl('/');
-      this.snackBar.open('記事を投稿しました', null, {
+      this.snackBar.open(msg, null, {
         duration: 2000,
       });
     });

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ElementRef } from '@angular/core';
+import { Component, OnInit, NgZone } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { ArticleService } from 'src/app/services/article.service';
 import { AuthService } from 'src/app/services/auth.service';
@@ -21,7 +21,6 @@ import 'froala-editor/js/plugins/paragraph_style.min.js';
 import 'froala-editor/js/plugins/paragraph_format.min.js';
 import 'froala-editor/js/plugins/quick_insert.min.js';
 import 'froala-editor/js/plugins/quote.min.js';
-import 'froala-editor/js/plugins/special_characters.min.js';
 import 'froala-editor/js/plugins/table.min.js';
 import 'froala-editor/js/plugins/url.min.js';
 import 'froala-editor/js/plugins/video.min.js';
@@ -35,11 +34,10 @@ import 'froala-editor/js/languages/ja.js';
 })
 export class CreateComponent implements OnInit {
   form = this.fb.group({
-    title: ['', [Validators.required, Validators.maxLength(80)]],
+    title: ['', [Validators.required, Validators.maxLength(255)]],
     tag: [''],
     editorContent: [''],
   });
-  editorPreview = '';
   froalaEditor;
 
   get titleControl() {
@@ -57,33 +55,58 @@ export class CreateComponent implements OnInit {
   public options = {
     toolbarSticky: false,
     toolbarInline: false,
-    height: '310',
+    height: '350',
     placeholderText: '作曲やDTMに関する知識を共有しよう',
     charCounterCount: true,
     language: 'ja',
-    toolbarButtons: {
+    toolbarButtonsSM: {
       moreText: {
-        buttons: ['bold', 'italic', 'underline', 'strikeThrough', 'textColor', 'clearFormatting']
+        buttons: ['bold', 'italic', 'underline', 'strikeThrough', 'textColor', 'clearFormatting'],
+        buttonsVisible: 3
       },
       moreParagraph: {
-        buttons: ['formatOL', 'formatUL', 'paragraphFormat', 'paragraphStyle', 'quote']
+        buttons: ['formatOL', 'formatUL', 'paragraphFormat', 'paragraphStyle', 'quote'],
+        buttonsVisible: 3
       },
       moreRich: {
-        buttons: ['insertLink', 'insertImage', 'insertVideo', 'insertTable', 'emoticons', 'specialCharacters']
+        buttons: ['insertLink', 'insertImage', 'insertVideo', 'insertTable', 'emoticons'],
+        buttonsVisible: 3
       },
       moreMisc: {
-        buttons: ['undo', 'redo', 'fullscreen']
+        buttons: ['undo', 'redo', 'fullscreen'],
+        align: 'right',
+        buttonsVisible: 3
+      }
+    },
+    toolbarButtonsXS: {
+      moreText: {
+        buttons: ['bold', 'italic', 'underline', 'strikeThrough', 'textColor', 'clearFormatting'],
+        buttonsVisible: 0
+      },
+      moreParagraph: {
+        buttons: ['formatOL', 'formatUL', 'paragraphFormat', 'paragraphStyle', 'quote'],
+        buttonsVisible: 0
+      },
+      moreRich: {
+        buttons: ['insertLink', 'insertImage', 'insertVideo', 'insertTable', 'emoticons'],
+        buttonsVisible: 0
+      },
+      moreMisc: {
+        buttons: ['undo', 'redo', 'fullscreen'],
+        align: 'right',
+        buttonsVisible: 3
       }
     },
     pastePlain: true,
     imageAddNewLine: true,
+    videoInsertButtons: ['videoBack', '|', 'videoByURL', 'videoEmbed'],
     events: {
       initialized: (editor) => {
         this.froalaEditor = editor;
       },
       'image.beforeUpload': (images) => {
         const file = images[0];
-        const fileSizeLimit = 2000000;
+        const fileSizeLimit = 3000000;
         const uid = this.authService.uid;
         if ((file.size < fileSizeLimit)) {
           const downloadURLPromise = this.articleService.uploadImage(uid, file);
@@ -92,15 +115,12 @@ export class CreateComponent implements OnInit {
           });
           return null;
         } else {
-          const msg = 'ファイルサイズは2MB以内にしてください';
-          this.snackBar.open(msg, '閉じる');
+          const msg = '３メガバイト未満の画像を利用してください';
+          this.ngZone.run(() => {
+            this.snackBar.open(msg, '閉じる');
+          });
           return false;
         }
-      },
-      'video.beforeUpload': () => {
-        const msg = 'すみません…動画はアップロードできません…';
-        this.snackBar.open(msg, '閉じる');
-        return false;
       },
     }
   };
@@ -112,6 +132,7 @@ export class CreateComponent implements OnInit {
     private snackBar: MatSnackBar,
     private router: Router,
     private route: ActivatedRoute,
+    private ngZone: NgZone,
   ) { }
 
   ngOnInit(): void { }

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -131,18 +131,30 @@ export class CreateComponent implements OnInit {
     private authService: AuthService,
     private snackBar: MatSnackBar,
     private router: Router,
-    private route: ActivatedRoute,
     private ngZone: NgZone,
   ) { }
 
   ngOnInit(): void { }
 
+  getFirstImageURL(html: string): string {
+    const imgTagPattern = /<img(?: .+?)?>.*?/i;
+    if (imgTagPattern.test(html)) {
+      const firstImgTag = html.match(imgTagPattern);
+      const srcPattern = /src=["|'](.*?)["|']+/i;
+      return firstImgTag[0].match(srcPattern)[1].replace(/&amp;/, '&');
+    } else {
+      return 'null';
+    }
+  }
+
   submit() {
     const formData = this.form.value;
+    const html = formData.editorContent;
+    const firstImageURL = this.getFirstImageURL(html);
     const sendData: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt'>
       = {
       uid: this.authService.uid,
-      imageURL: 'http://placekitten.com/700/300',
+      thumbnailURL: firstImageURL,
       title: formData.title,
       tag: 'DTM',
       text: formData.editorContent,

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, NgZone } from '@angular/core';
+import { Component, OnInit, NgZone, HostListener } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
 import { ArticleService } from 'src/app/services/article.service';
 import { AuthService } from 'src/app/services/auth.service';
@@ -39,6 +39,7 @@ export class CreateComponent implements OnInit {
     editorContent: [''],
   });
   froalaEditor;
+  isComplete: boolean;
 
   get titleControl() {
     return this.form.get('title') as FormControl;
@@ -136,6 +137,14 @@ export class CreateComponent implements OnInit {
 
   ngOnInit(): void { }
 
+  @HostListener('window:beforeunload', ['$event'])
+  unloadNotification($event: any) {
+    if (this.form.dirty) {
+      $event.preventDefault();
+      $event.returnValue = '作業中の内容が失われますがよろしいですか？';
+    }
+  }
+
   getFirstImageURL(html: string): string {
     const imgTagPattern = /<img(?: .+?)?>.*?/i;
     if (imgTagPattern.test(html)) {
@@ -159,6 +168,7 @@ export class CreateComponent implements OnInit {
       tag: 'DTM',
       text: formData.editorContent,
     };
+    this.isComplete = true;
     this.articleService.createArticle(sendData).then(() => {
       this.router.navigateByUrl('/');
       this.snackBar.open('記事を投稿しました', null, {

--- a/src/app/notes/notes-routing.module.ts
+++ b/src/app/notes/notes-routing.module.ts
@@ -2,11 +2,13 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { NotesComponent } from './notes/notes.component';
 import { CreateComponent } from './create/create.component';
+import { FormGuard } from '../guards/form.guard';
 
 const routes: Routes = [
   {
     path: 'create',
     component: CreateComponent,
+    canDeactivate: [FormGuard],
   },
   {
     path: '',
@@ -19,4 +21,4 @@ const routes: Routes = [
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule],
 })
-export class NotesRoutingModule {}
+export class NotesRoutingModule { }

--- a/src/app/notes/notes.module.ts
+++ b/src/app/notes/notes.module.ts
@@ -8,7 +8,7 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
-import { AngularEditorModule } from '@kolkov/angular-editor';
+import { FroalaViewModule, FroalaEditorModule } from 'angular-froala-wysiwyg';
 
 @NgModule({
   declarations: [NotesComponent, CreateComponent],
@@ -20,7 +20,8 @@ import { AngularEditorModule } from '@kolkov/angular-editor';
     MatInputModule,
     MatFormFieldModule,
     MatButtonModule,
-    AngularEditorModule
+    FroalaEditorModule,
+    FroalaViewModule,
   ],
 })
 export class NotesModule { }

--- a/src/app/notes/notes.module.ts
+++ b/src/app/notes/notes.module.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
 import { FroalaViewModule, FroalaEditorModule } from 'angular-froala-wysiwyg';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 @NgModule({
   declarations: [NotesComponent, CreateComponent],
@@ -22,6 +23,7 @@ import { FroalaViewModule, FroalaEditorModule } from 'angular-froala-wysiwyg';
     MatButtonModule,
     FroalaEditorModule,
     FroalaViewModule,
+    MatSlideToggleModule,
   ],
 })
 export class NotesModule { }

--- a/src/app/notes/notes.module.ts
+++ b/src/app/notes/notes.module.ts
@@ -8,7 +8,6 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatButtonModule } from '@angular/material/button';
-import { MatCardModule } from '@angular/material/card';
 import { AngularEditorModule } from '@kolkov/angular-editor';
 
 @NgModule({
@@ -21,7 +20,6 @@ import { AngularEditorModule } from '@kolkov/angular-editor';
     MatInputModule,
     MatFormFieldModule,
     MatButtonModule,
-    MatCardModule,
     AngularEditorModule
   ],
 })

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -16,7 +16,7 @@ export class ArticleService {
 
   async uploadImage(uid: string, file: File): Promise<void> {
     const time: number = new Date().getTime();
-    const result = await this.storage.ref(`upload_images/${uid}/${time}`).put(file);
+    const result = await this.storage.ref(`users/${uid}/images/${time}`).put(file);
     return await result.ref.getDownloadURL();
   }
 

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -3,6 +3,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { Article } from '../interfaces/article';
 import { Observable } from 'rxjs';
 import { firestore } from 'firebase/app';
+import { AngularFireStorage } from '@angular/fire/storage';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +11,14 @@ import { firestore } from 'firebase/app';
 export class ArticleService {
   constructor(
     private db: AngularFirestore,
+    private storage: AngularFireStorage,
   ) { }
+
+  async uploadImage(uid: string, file: File): Promise<void> {
+    const time: number = new Date().getTime();
+    const result = await this.storage.ref(`upload_images/${uid}/${time}`).put(file);
+    return await result.ref.getDownloadURL();
+  }
 
   createArticle(article: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt'>
   ): Promise<void> {

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -20,7 +20,7 @@ export class ArticleService {
     return await result.ref.getDownloadURL();
   }
 
-  createArticle(article: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt' | 'thumbnailURL'>
+  createArticle(article: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt' | 'thumbnailURL' | 'isPublic'>
   ): Promise<void> {
     const articleId = this.db.createId();
     return this.db.doc(`articles/${articleId}`).set({

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -32,12 +32,11 @@ export class ArticleService {
   }
 
   getAllArticles(): Observable<Article[]> {
-    return this.db.collection<Article>(`articles`).valueChanges();
+    return this.db.collection<Article>(`articles`, ref => ref.where('isPublic', '==', true)).valueChanges();
   }
 
   getArticles(uid: string): Observable<Article[]> {
-    return this.db.collection<Article>(`articles`, ref => ref.where('uid', '==', uid))
-      .valueChanges();
+    return this.db.collection<Article>(`articles`, ref => ref.where('uid', '==', uid).where('isPublic', '==', true)).valueChanges();
   }
 
   getArticleOnly(articleId: string): Observable<Article> {

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -20,7 +20,7 @@ export class ArticleService {
     return await result.ref.getDownloadURL();
   }
 
-  createArticle(article: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt'>
+  createArticle(article: Omit<Article, 'articleId' | 'createdAt' | 'updatedAt' | 'thumbnailURL'>
   ): Promise<void> {
     const articleId = this.db.createId();
     return this.db.doc(`articles/${articleId}`).set({

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -53,15 +53,15 @@ export class AuthService {
       })
       .catch((error) => {
         this.router.navigateByUrl('/');
-        const errorMessage = error.message;
-        this.snackBar.open(errorMessage, null, { duration: 2000 });
+        console.log(error.message);
+        this.snackBar.open('ログインエラーです。数秒後にもう一度お試しください。', '閉じる', { duration: 5000 });
       });
   }
 
   logout() {
     this.afAuth.signOut().then(() => {
       this.router.navigateByUrl('/');
-      this.snackBar.open('ログアウトしました', null, { duration: 2000 });
+      this.snackBar.open('ログアウトしました。', '閉じる', { duration: 5000 });
     });
   }
 }

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,6 +1,6 @@
 <div class="card">
   <a [routerLink]="'/komura_c/n/' + article.articleId" class="card__inner">
-    <ng-container *ngIf="article.thumbnailURL">
+    <ng-container *ngIf="article.thumbnailURL && article.thumbnailURL != 'null'">
       <img class="card__thumbnail-image" [src]="article.thumbnailURL" alt="サムネイル画像">
     </ng-container>
     <h3 class="card__title" (click)="$event.stopPropagation(); $event.preventDefault()"

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,6 +1,8 @@
 <div class="card">
   <a [routerLink]="'/komura_c/n/' + article.articleId" class="card__inner">
-    <img class="card__thumbnail-image" [src]="article.imageURL" alt="サムネイル画像">
+    <ng-container *ngIf="article.thumbnailURL">
+      <img class="card__thumbnail-image" [src]="article.thumbnailURL" alt="サムネイル画像">
+    </ng-container>
     <h3 class="card__title" (click)="$event.stopPropagation(); $event.preventDefault()"
       [routerLink]="'/komura_c/n/' + article.articleId">
       {{ article.title }}

--- a/src/app/shared/article/article.component.scss
+++ b/src/app/shared/article/article.component.scss
@@ -15,6 +15,8 @@
   }
   &__thumbnail-image {
     border-radius: 4px;
+    max-width: 100%;
+    max-height: 300px;
   }
   &__title {
     margin: 8px 0;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -24,6 +24,11 @@ img {
   background-color: #ffffff;
 }
 
+//  froala-editor
+.fr-element.fr-view p {
+  font-size: 16px;
+}
+
 @media screen and (max-width: 480px) {
   .container {
     padding: 126px 16px 16px 16px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -23,6 +23,9 @@ img {
   padding: 76px 16px 16px 16px;
   background-color: #ffffff;
 }
+.angular-editor-textarea {
+  margin: 0 !important;
+}
 
 @media screen and (max-width: 480px) {
   .container {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -23,9 +23,6 @@ img {
   padding: 76px 16px 16px 16px;
   background-color: #ffffff;
 }
-.angular-editor-textarea {
-  margin: 0 !important;
-}
 
 @media screen and (max-width: 480px) {
   .container {


### PR DESCRIPTION
fix #45 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ

![editor](https://user-images.githubusercontent.com/37304826/87264599-62b3b000-c4fb-11ea-9ac6-8b1657ae8e3b.gif)

## 作業概要

- ビルドエラーを修正
- Froala Editorの導入 
- FirebaseStorageに画像アップロードの実装
- 一つの画像につき、3MB未満のバリデーションを設定
- NgZoneを使って、snackBarの挙動がおかしいのを修正
- 正規表現で記事最初の画像を取得し、サムネイルURLとして保存
- 離脱ガードの設定
- app.component.tsでdataを取得し、create画面でフッター非表示
- キャンセルボタンにブラウザの戻る挙動のlocation.back()を実装
- 各画面で非公開記事を表示しない実装、記事詳細画面は投稿者のみが表示できるように実装
- スタイル調整