### PR TITLE
ローディングUIの追加、 aタグでリンクを有効化、未ログイン時サービス概要を表示

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,9 @@
 <app-header></app-header>
 <div class="container">
   <router-outlet></router-outlet>
+  <div *ngIf="loading$ | async">
+    <mat-spinner class="loading-bar" diameter="100" strokeWidth="8"></mat-spinner>
+  </div>
 </div>
 <ng-container *ngIf="activatedRouteData | async as data">
   <app-footer *ngIf="!data.isNotShowFooter"></app-footer>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Router, NavigationEnd, ActivatedRoute, Data } from '@angular/router';
 import { Observable } from 'rxjs';
+import { LoadingService } from './services/loading.service';
 
 @Component({
   selector: 'app-root',
@@ -10,7 +11,14 @@ import { Observable } from 'rxjs';
 export class AppComponent {
   title = 'dtmplace';
   activatedRouteData: Observable<Data>;
-  constructor(private router: Router, private activatedRoute: ActivatedRoute) {
+
+  loading$ = this.loadingService.loading$;
+
+  constructor(
+    private router: Router,
+    private activatedRoute: ActivatedRoute,
+    private loadingService: LoadingService,
+  ) {
     this.router.events.forEach(event => {
       if ((event instanceof NavigationEnd)) {
         this.activatedRouteData = this.activatedRoute.firstChild.data;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { MatListModule } from '@angular/material/list';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { SharedModule } from './shared/shared.module';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 @NgModule({
   declarations: [AppComponent, HeaderComponent, FooterComponent, NotFoundComponent, SearchResultComponent, SearchInputComponent],
@@ -50,6 +51,7 @@ import { SharedModule } from './shared/shared.module';
     ReactiveFormsModule,
     MatAutocompleteModule,
     SharedModule,
+    MatProgressSpinnerModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -6,7 +6,8 @@
     <app-search-input class="search"></app-search-input>
 
     <ng-template #default>
-      <button [disabled]="isProcessing" (click)="login()" mat-flat-button color="primary" medium class="login-button">
+      <button [disabled]="isProcessing" (click)="login()" mat-flat-button color="primary" medium class="login-button"
+        *ngIf="isUser">
         <mat-icon><img src="/assets/icons/twitter_logo_white.png" alt="Twitterロゴ"></mat-icon>
         <span>{{isProcessing ? 'ログイン中' : 'ログイン'}}</span>
       </button>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
+import { tap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-header',
@@ -7,8 +8,9 @@ import { AuthService } from '../services/auth.service';
   styleUrls: ['./header.component.scss']
 })
 export class HeaderComponent implements OnInit {
-  user$ = this.authService.user$;
+  user$ = this.authService.user$.pipe(tap(() => this.isUser = true));
   isProcessing: boolean;
+  isUser: boolean;
 
   constructor(
     private authService: AuthService,

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -5,8 +5,11 @@ import { HomeRoutingModule } from './home-routing.module';
 import { HomeComponent } from './home/home.component';
 import { MatTabsModule } from '@angular/material/tabs';
 import { SharedModule } from '../shared/shared.module';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+
 @NgModule({
   declarations: [HomeComponent],
-  imports: [CommonModule, HomeRoutingModule, MatTabsModule, SharedModule],
+  imports: [CommonModule, HomeRoutingModule, MatTabsModule, SharedModule, MatIconModule, MatButtonModule],
 })
 export class HomeModule { }

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -1,5 +1,17 @@
 <div class="home-page">
   <div class="home-main">
+    <ng-container *ngIf="!(user$ | async)">
+      <div class="welcome">
+        <h1 class="welcome__title">音楽に関する知識を共有しよう</h1>
+        <h2 class="welcome__sub-title">MusiLは、DTMや作曲に関する知識を記録・共有するためのサービスです。</h2>
+        <p><a routerLink="/terms" class="terms-link">利用規約</a>に同意し、
+          <button [disabled]="isProcessing" (click)="login()" mat-flat-button color="primary" medium
+            class="login-button">
+            <mat-icon><img src="/assets/icons/twitter_logo_white.png" alt="Twitterロゴ"></mat-icon>
+            <span>{{isProcessing ? 'ログイン中' : 'Twitterでログイン'}}</span>
+          </button></p>
+      </div>
+    </ng-container>
     <h3 class="home-main__title">トレンド</h3>
     <ng-container *ngFor="let article of articles$ | async">
       <app-article *ngIf="article" [article]="article"></app-article>

--- a/src/app/home/home/home.component.scss
+++ b/src/app/home/home/home.component.scss
@@ -24,6 +24,22 @@
   }
 }
 
+.login-button {
+  background-color: #1da1f2;
+}
+
+.terms-link {
+  color: #ff5500;
+}
+
+.welcome {
+  &__title {
+    font-size: 24px;
+  }
+  &__sub-title {
+    font-size: 16px;
+  }
+}
 @media screen and (max-width: 940px) {
   .home-sub {
     max-width: 610px;

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { ArticleWithAuthor } from 'functions/src/interfaces/article-with-author';
 import { tap } from 'rxjs/operators';
 import { LoadingService } from 'src/app/services/loading.service';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-home',
@@ -11,6 +12,8 @@ import { LoadingService } from 'src/app/services/loading.service';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
+  isProcessing: boolean;
+  user$ = this.authService.user$;
 
   articles$: Observable<ArticleWithAuthor[]> = this.articleService.getArticlesWithAuthors().pipe(
     tap(() => this.loadingService.toggleLoading(false))
@@ -19,8 +22,16 @@ export class HomeComponent implements OnInit {
   constructor(
     private articleService: ArticleService,
     private loadingService: LoadingService,
+    private authService: AuthService,
   ) {
     this.loadingService.toggleLoading(true);
+  }
+
+  login() {
+    this.isProcessing = true;
+    this.authService.login().finally(() => {
+      this.isProcessing = false;
+    });
   }
 
   ngOnInit(): void { }

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -2,6 +2,8 @@ import { Component, OnInit } from '@angular/core';
 import { ArticleService } from 'src/app/services/article.service';
 import { Observable } from 'rxjs';
 import { ArticleWithAuthor } from 'functions/src/interfaces/article-with-author';
+import { tap } from 'rxjs/operators';
+import { LoadingService } from 'src/app/services/loading.service';
 
 @Component({
   selector: 'app-home',
@@ -9,11 +11,17 @@ import { ArticleWithAuthor } from 'functions/src/interfaces/article-with-author'
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
-  articles$: Observable<ArticleWithAuthor[]> = this.articleService.getArticlesWithAuthors();
+
+  articles$: Observable<ArticleWithAuthor[]> = this.articleService.getArticlesWithAuthors().pipe(
+    tap(() => this.loadingService.toggleLoading(false))
+  );
 
   constructor(
     private articleService: ArticleService,
-  ) { }
+    private loadingService: LoadingService,
+  ) {
+    this.loadingService.toggleLoading(true);
+  }
 
   ngOnInit(): void { }
 }

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -5,7 +5,7 @@
       <div class="mypage__user-profile">
         <h2 class="mypage__user-name">{{user.userName}}</h2>
         <p class="mypage__user-screen-name">@{{user.screenName}}</p>
-        <p class="mypage__user-description">{{user.description}}</p>
+        <p class="mypage__user-description" [innerHTML]="stringToLink(user.description)"></p>
         <a [href]="'https://twitter.com/' + user.screenName" class="mypage__twitter-icon">
           <mat-icon>
             <img src="/assets/icons/twitter-logo_blue.png" alt="Twitterロゴ">

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,5 +1,5 @@
 <div class="mypage">
-  <ng-container *ngIf="user$ | async as user; else notFound;">
+  <ng-container *ngIf="user$ | async as user">
     <div class="mypage__author">
       <img [src]="user.avatarURL" class="mypage__user-icon" alt="プロフィール画像">
       <div class="mypage__user-profile">
@@ -16,22 +16,36 @@
     <mat-tab-group mat-stretch-tabs class="mypage__menu">
       <mat-tab label="記事">
         <div class="mypage__body">
-          <ng-container *ngFor="let article of articles$ | async">
-            <app-article *ngIf="article" [article]="article"></app-article>
+          <ng-container *ngIf="articles$ | async as articles">
+            <ng-container *ngIf="articles.length === 0">
+              <div class="no-article">
+                <p>まだ、記事はありません。</p>
+              </div>
+            </ng-container>
+            <ng-container *ngFor="let article of articles">
+              <app-article *ngIf="article" [article]="article"></app-article>
+            </ng-container>
           </ng-container>
         </div>
       </mat-tab>
       <mat-tab label="いいね">
         <div class="mypage__body">
-          <ng-container *ngFor="let article of articles$ | async">
-            <app-article *ngIf="article" [article]="article"></app-article>
+          <ng-container *ngIf="articles$ | async as articles">
+            <ng-container *ngIf="articles.length === 0">
+              <div class="no-article">
+                <p>まだ、記事はありません。</p>
+              </div>
+            </ng-container>
+            <ng-container *ngFor="let article of articles">
+              <app-article *ngIf="article" [article]="article"></app-article>
+            </ng-container>
           </ng-container>
         </div>
       </mat-tab>
     </mat-tab-group>
   </ng-container>
 
-  <ng-template #notFound>
+  <ng-container *ngIf="isNotFoundUser">
     <p class="error">「{{screenName}}」というユーザーは存在しませんでした。</p>
-  </ng-template>
+  </ng-container>
 </div>

--- a/src/app/mypage/mypage/mypage.component.scss
+++ b/src/app/mypage/mypage/mypage.component.scss
@@ -27,6 +27,9 @@
   }
   &__user-description {
     margin: 0 0 8px 0;
+    a {
+      color: #1da1f2;
+    }
   }
   &__twitter-icon {
     .mat-icon {

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { UserService } from 'src/app/services/user.service';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { ArticleService } from 'src/app/services/article.service';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, tap, catchError } from 'rxjs/operators';
 import { UserData } from 'functions/src/interfaces/user';
 import { ArticleWithAuthor } from 'functions/src/interfaces/article-with-author';
 import { Article } from 'functions/src/interfaces/article';
+import { LoadingService } from 'src/app/services/loading.service';
 
 @Component({
   selector: 'app-mypage',
@@ -18,16 +19,24 @@ export class MypageComponent implements OnInit {
   screenName: string;
   articles$: Observable<ArticleWithAuthor[]>;
 
+  isNotFoundUser: boolean;
+
   constructor(
     private route: ActivatedRoute,
     private userService: UserService,
     private articleService: ArticleService,
+    private loadingService: LoadingService,
   ) {
+    this.loadingService.toggleLoading(true);
     this.route.paramMap.subscribe(params => {
       this.screenName = params.get('id');
-      this.user$ = this.userService.getUserByScreenName(
-        this.screenName
-      );
+      this.user$ = this.userService.getUserByScreenName(this.screenName)
+        .pipe(tap(() => this.loadingService.toggleLoading(false)),
+          catchError(err => of(null).pipe(tap(() => {
+            this.loadingService.toggleLoading(false);
+            this.isNotFoundUser = true;
+          })),
+          ));
       let author: UserData;
       this.articles$ = this.user$.pipe(
         map((user: UserData) => {

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -30,13 +30,13 @@ export class MypageComponent implements OnInit {
     this.loadingService.toggleLoading(true);
     this.route.paramMap.subscribe(params => {
       this.screenName = params.get('id');
-      this.user$ = this.userService.getUserByScreenName(this.screenName)
-        .pipe(tap(() => this.loadingService.toggleLoading(false)),
+      this.user$ = this.userService.getUserByScreenName(this.screenName).pipe(
+        tap(() => this.loadingService.toggleLoading(false),
           catchError(err => of(null).pipe(tap(() => {
             this.loadingService.toggleLoading(false);
             this.isNotFoundUser = true;
           })),
-          ));
+          )));
       let author: UserData;
       this.articles$ = this.user$.pipe(
         map((user: UserData) => {
@@ -59,7 +59,13 @@ export class MypageComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void {
+  stringToLink(description: string): string {
+    const linkReg = new RegExp(/(http(s)?:\/\/[a-zA-Z0-9-.!'()*;/?:@&=+$,%#]+)/gi);
+    const toATag = '<a href=\'$1\' target=\'_blank\'>$1</a>';
+    const link = description.replace(linkReg, toATag);
+    return link;
   }
 
+  ngOnInit(): void {
+  }
 }

--- a/src/app/mypage/note/note.component.html
+++ b/src/app/mypage/note/note.component.html
@@ -66,7 +66,7 @@
           <div class="note-footer__user-profile">
             <a class="note-footer__user-name"
               [routerLink]="'/' + article.author.screenName">{{article.author.userName}}</a>
-            <p class="note-footer__user-description">{{article.author.description}}</p>
+            <p class="note-footer__user-description" [innerHTML]="stringToLink(article.author.description)"></p>
             <a class="note-footer__twitter" [href]="'https://twitter.com/' + article.author.screenName" target="_blank">
               <mat-icon>
                 <img src="/assets/icons/twitter-logo_blue.png" alt="Twitterロゴ">

--- a/src/app/mypage/note/note.component.html
+++ b/src/app/mypage/note/note.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="article$ | async as article; else notFound;">
+<ng-container *ngIf="article$ | async as article">
   <div class="note">
     <div class="note__left-box">
       <div class="left-actions">
@@ -92,6 +92,6 @@
   </div>
 </ng-container>
 
-<ng-template #notFound>
+<ng-container *ngIf="isNotFoundArticle">
   <p class="error">「{{articleId}}」という記事は存在しませんでした。</p>
-</ng-template>
+</ng-container>

--- a/src/app/mypage/note/note.component.ts
+++ b/src/app/mypage/note/note.component.ts
@@ -107,6 +107,13 @@ export class NoteComponent implements OnInit {
     }, 100);
   }
 
+  stringToLink(description: string): string {
+    const linkReg = new RegExp(/(http(s)?:\/\/[a-zA-Z0-9-.!'()*;/?:@&=+$,%#]+)/gi);
+    const toATag = '<a href=\'$1\' target=\'_blank\'>$1</a>';
+    const link = description.replace(linkReg, toATag);
+    return link;
+  }
+
   ngOnInit(): void {
   }
 

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -138,18 +138,17 @@ export class CreateComponent implements OnInit {
         }
       },
       'link.beforeInsert': (link, text) => {
-        const httpPattern = /^(https|http):\/\//;
-        if (!httpPattern.test(link)) {
+        const httpReg = new RegExp(/^(https|http):\/\//);
+        if (!httpReg.test(link)) {
           this.ngZone.run(() => {
             const msg = '正しいURLではありません';
             this.snackBar.open(msg, '閉じる', { duration: 5000 });
           });
           return false;
         }
-        const soundCloudPattern = /^(https|http):\/\/soundcloud\.com(\/.*|\?.*|$)/;
-        if (soundCloudPattern.test(link)) {
-          const soundCloudURL = link.match(soundCloudPattern);
-          console.log(soundCloudURL);
+        const soundCloudReg = new RegExp(/^(https|http):\/\/soundcloud\.com(\/.*|\?.*|$)/);
+        if (soundCloudReg.test(link)) {
+          const soundCloudURL = link.match(soundCloudReg);
           const soundCloudEmbedPlayer = '<iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A//soundcloud.com' + soundCloudURL[2] + '&color=%23ff5500&auto_play=false&hide_related=true&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe>' + text;
           const currentValue = this.form.value;
           this.form.patchValue({
@@ -211,11 +210,11 @@ export class CreateComponent implements OnInit {
   }
 
   getFirstImageURL(html: string): string {
-    const imgTagPattern = /<img(?: .+?)?>.*?/i;
-    if (imgTagPattern.test(html)) {
-      const firstImgTag = html.match(imgTagPattern);
-      const srcPattern = /src=["|'](.*?)["|']+/i;
-      return firstImgTag[0].match(srcPattern)[1].replace(/&amp;/, '&');
+    const imgTagReg = new RegExp(/<img(?: .+?)?>.*?/i);
+    if (imgTagReg.test(html)) {
+      const firstImgTag = html.match(imgTagReg);
+      const srcReg = new RegExp(/src=["|'](.*?)["|']+/i);
+      return firstImgTag[0].match(srcReg)[1].replace(/&amp;/, '&');
     } else {
       return 'null';
     }

--- a/src/app/notes/notes/notes.component.html
+++ b/src/app/notes/notes/notes.component.html
@@ -1,6 +1,6 @@
 <div class="notes">
   <h1 class="notes__title">記事一覧</h1>
-  <ng-container *ngIf="articles$ | async as articles; else noArticle;">
+  <ng-container *ngIf="articles$ | async as articles">
     <div class="notes__list-header">
       <div class="list-header__num">{{articles.length}} 記事</div>
     </div>
@@ -41,14 +41,14 @@
         </div>
       </div>
     </ng-container>
+    <ng-container *ngIf="articles.length === 0">
+      <div class="no-article">
+        <p>まだ、記事がありません。記事を投稿してみよう。</p>
+        <button mat-flat-button color="warn" class="post-button" routerLink="/notes/create">
+          <mat-icon>post_add</mat-icon>
+          <span>投稿</span>
+        </button>
+      </div>
+    </ng-container>
   </ng-container>
-  <ng-template #noArticle>
-    <div class="no-article">
-      <p>まだ、記事がありません。記事を投稿してみよう。</p>
-      <button mat-flat-button color="warn" class="post-button" routerLink="/notes/create">
-        <mat-icon>post_add</mat-icon>
-        <span>投稿</span>
-      </button>
-    </div>
-  </ng-template>
 </div>

--- a/src/app/notes/notes/notes.component.ts
+++ b/src/app/notes/notes/notes.component.ts
@@ -7,6 +7,8 @@ import { MatDialog } from '@angular/material/dialog';
 import { DeleteDialogComponent } from 'src/app/shared/delete-dialog/delete-dialog.component';
 import { Article } from 'functions/src/interfaces/article';
 import { UserData } from 'functions/src/interfaces/user';
+import { LoadingService } from 'src/app/services/loading.service';
+import { tap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-notes',
@@ -15,15 +17,20 @@ import { UserData } from 'functions/src/interfaces/user';
 })
 export class NotesComponent implements OnInit {
   uid = this.authService.uid;
-  articles$: Observable<Article[]> = this.articleService.getMyArticles(this.uid);
+  articles$: Observable<Article[]> = this.articleService.getMyArticles(this.uid).pipe(
+    tap(() => this.loadingService.toggleLoading(false))
+  );
   user$: Observable<UserData> = this.userService.getUserData(this.uid);
 
   constructor(
     private articleService: ArticleService,
     private authService: AuthService,
     private userService: UserService,
-    private dialog: MatDialog
-  ) { }
+    private dialog: MatDialog,
+    private loadingService: LoadingService,
+  ) {
+    this.loadingService.toggleLoading(true);
+  }
 
   ngOnInit(): void {
   }

--- a/src/app/search-input/search-input.component.ts
+++ b/src/app/search-input/search-input.component.ts
@@ -37,10 +37,13 @@ export class SearchInputComponent implements OnInit {
     });
   }
 
-  routeSearch(q: string) {
+  routeSearch(keyword: string) {
+    if (keyword === null) {
+      keyword = '';
+    }
     this.router.navigate(['/search'], {
       queryParamsHandling: 'merge',
-      queryParams: { q },
+      queryParams: { q: keyword },
     });
   }
 

--- a/src/app/services/loading.service.spec.ts
+++ b/src/app/services/loading.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { LoadingService } from './loading.service';
+
+describe('LoadingService', () => {
+  let service: LoadingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LoadingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/loading.service.ts
+++ b/src/app/services/loading.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { Subject, Observable } from 'rxjs';
+import { Article } from '@interfaces/article';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class LoadingService {
+  loadingSource = new Subject();
+  loading$ = this.loadingSource.asObservable();
+
+  constructor() { }
+
+  toggleLoading(status: boolean) {
+    this.loadingSource.next(status);
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
 
 <body>
   <app-root></app-root>
-  <script async type="text/javascript" src="http://cdn.embedly.com/widgets/platform.js"></script>
+  <script async src="//cdn.embedly.com/widgets/platform.js" charset="UTF-8"></script>
 </body>
 
 </html>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -30,6 +30,9 @@ img {
 .mypage__user-description a {
   color: #ff5500;
 }
+.note-footer__user-description a {
+  color: #ff5500;
+}
 
 //  froala-editor
 .fr-element.fr-view p {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -27,9 +27,16 @@ img {
   margin: 40px auto;
 }
 
+.mypage__user-description a {
+  color: #ff5500;
+}
+
 //  froala-editor
 .fr-element.fr-view p {
   font-size: 16px;
+}
+.fr-view a {
+  color: #ff5500;
 }
 .fr-embedly {
   width: 100%;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -23,6 +23,9 @@ img {
   padding: 76px 16px 16px 16px;
   background-color: #ffffff;
 }
+.loading-bar {
+  margin: 40px auto;
+}
 
 //  froala-editor
 .fr-element.fr-view p {


### PR DESCRIPTION
fix #22 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ

![画面収録 2020-07-22 2 39 41 mov](https://user-images.githubusercontent.com/37304826/88088124-e852f200-cbc4-11ea-8bfa-7520133b832d.gif)

## 作業概要
- ローディングUIの追加、referctor、スタイル調整
- embedlyの弾かれたscriptを修正
- 記事詳細画面のTableOfContentも修正
- mypageのリンクをaタグで有効化、スタイル調整
- 記事詳細画面のリンクも実装
- 正規表現をきちんとRegExpと明示
- 未ログイン時ホームページにサービス概要を表示