### PR TITLE
ログイン時処理の修正、設定画面の実装、記事編集ボタン追加、検索処理修正、スタイル調整 #30

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,7 @@
 export {
   createUser,
+  deleteUser,
+  deleteUserArticles,
 } from './user.function';
 export {
   createPost,

--- a/functions/src/interfaces/article.ts
+++ b/functions/src/interfaces/article.ts
@@ -1,4 +1,4 @@
-import { firestore } from 'firebase';
+import { firestore } from 'firebase/app';
 
 export interface Article {
   articleId: string;

--- a/functions/src/user.function.ts
+++ b/functions/src/user.function.ts
@@ -32,7 +32,7 @@ export const deleteUser = functions.region('asia-northeast1').auth.user()
 export const deleteUserArticles = functions.region('asia-northeast1').auth.user()
   .onDelete(async user => {
     const articles = await db.collection('articles')
-      .where('authorId', '==', user.uid).get();
+      .where('uid', '==', user.uid).get();
     const batch = db.batch();
     articles.forEach((doc) => {
       batch.delete(doc.ref);

--- a/functions/src/user.function.ts
+++ b/functions/src/user.function.ts
@@ -7,13 +7,13 @@ const db = admin.firestore();
 
 export const createUser = functions.region('asia-northeast1').auth.user().onCreate((user) => {
   if (user.displayName && user.photoURL) {
-    const sendUserData: Omit<UserData, 'screenName' | 'description'> = {
+    const userData: Omit<UserData, 'screenName' | 'description'> = {
       uid: user.uid,
       userName: user.displayName,
-      avatarURL: user.photoURL?.replace('_normal', '')
+      avatarURL: user.photoURL?.replace('_normal', ''),
     };
-    return db.doc(`users/${user.uid}`).set(sendUserData);
+    return db.doc(`users/${user.uid}`).set(userData, { merge: true });
   } else {
-    return db.doc(`users/${user.uid}`).set({ uid: user.uid });
+    return db.doc(`users/${user.uid}`).set({ uid: user.uid }, { merge: true });
   }
 });

--- a/functions/src/utils/util.ts
+++ b/functions/src/utils/util.ts
@@ -1,0 +1,29 @@
+import * as admin from 'firebase-admin';
+
+const db = admin.firestore();
+
+export function markEventTried(eventId: string) {
+  const documentRef = db.collection('functionEvents').doc(eventId);
+  return documentRef.set({ tried: true });
+}
+
+const leaseTime = 60 * 1000;
+
+export function shouldEventRun(eventId: string) {
+  const documentRef = db.collection('functionEvents').doc(eventId);
+  return db.runTransaction((transaction) => {
+    return transaction.get(documentRef).then((doc) => {
+      const data = doc.data();
+      if (doc.exists && data && data.tried) {
+        return false;
+      }
+      if (doc.exists && data && new Date() < data.lease) {
+        return Promise.reject('Lease already taken, try later.');
+      }
+      transaction.set(documentRef, {
+        lease: new Date(new Date().getTime() + leaseTime),
+      });
+      return true;
+    });
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8606,6 +8606,12 @@
         }
       }
     },
+    "hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=",
+      "optional": true
+    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
@@ -11390,6 +11396,15 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "ngx-image-cropper": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ngx-image-cropper/-/ngx-image-cropper-3.2.0.tgz",
+      "integrity": "sha512-adEhWwmRDViRcKTjjQ46/3UuVAx+EblGsRjUOJUb4S0RsGcKp7U/02GYRqnQ6Tjah9i9/dba3PZt3p80c8mIGA==",
+      "requires": {
+        "hammerjs": "^2.0.8",
+        "tslib": "^1.9.0"
+      }
     },
     "nice-try": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "algoliasearch": "^4.3.0",
     "angular-froala-wysiwyg": "^3.1.0",
     "firebase": "^7.15.5",
+    "ngx-image-cropper": "^3.2.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
     "zone.js": "~0.10.2"

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,6 +6,13 @@ import { SearchResultComponent } from './search-result/search-result.component';
 
 const routes: Routes = [
   {
+    path: 'settings',
+    loadChildren: () =>
+      import('./settings/settings.module').then((m) => m.SettingsModule),
+    canLoad: [AuthGuard],
+    canActivate: [AuthGuard]
+  },
+  {
     path: 'search',
     component: SearchResultComponent,
   },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { SharedModule } from './shared/shared.module';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatDividerModule } from '@angular/material/divider';
 
 @NgModule({
   declarations: [AppComponent, HeaderComponent, FooterComponent, NotFoundComponent, SearchResultComponent, SearchInputComponent],
@@ -52,6 +53,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
     MatAutocompleteModule,
     SharedModule,
     MatProgressSpinnerModule,
+    MatDividerModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -29,9 +29,14 @@
             <mat-icon>account_box</mat-icon>
             <span>マイページ</span>
           </button>
-          <button mat-menu-item mat-menu-item routerLink="/notes">
+          <button mat-menu-item routerLink="/notes">
             <mat-icon>article</mat-icon>
             <span>記事一覧</span>
+          </button>
+          <mat-divider></mat-divider>
+          <button mat-menu-item routerLink="/settings">
+            <mat-icon>settings</mat-icon>
+            <span>設定</span>
           </button>
           <button (click)="logout()" mat-menu-item class="logout-button">
             <mat-icon>exit_to_app</mat-icon>

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -5,6 +5,7 @@ import { ArticleWithAuthor } from 'functions/src/interfaces/article-with-author'
 import { tap } from 'rxjs/operators';
 import { LoadingService } from 'src/app/services/loading.service';
 import { AuthService } from 'src/app/services/auth.service';
+import { UserData } from '@interfaces/user';
 
 @Component({
   selector: 'app-home',
@@ -13,7 +14,7 @@ import { AuthService } from 'src/app/services/auth.service';
 })
 export class HomeComponent implements OnInit {
   isProcessing: boolean;
-  user$ = this.authService.user$;
+  user$: Observable<UserData> = this.authService.user$;
 
   articles$: Observable<ArticleWithAuthor[]> = this.articleService.getArticlesWithAuthors().pipe(
     tap(() => this.loadingService.toggleLoading(false))

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { ArticleService } from 'src/app/services/article.service';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { ArticleWithAuthor } from 'functions/src/interfaces/article-with-author';
-import { tap } from 'rxjs/operators';
+import { tap, catchError } from 'rxjs/operators';
 import { LoadingService } from 'src/app/services/loading.service';
 import { AuthService } from 'src/app/services/auth.service';
 import { UserData } from '@interfaces/user';
@@ -17,7 +17,12 @@ export class HomeComponent implements OnInit {
   user$: Observable<UserData> = this.authService.user$;
 
   articles$: Observable<ArticleWithAuthor[]> = this.articleService.getArticlesWithAuthors().pipe(
-    tap(() => this.loadingService.toggleLoading(false))
+    tap(() => this.loadingService.toggleLoading(false)),
+    catchError((error) => {
+      console.log(error.message);
+      this.loadingService.toggleLoading(false);
+      return of(null);
+    })
   );
 
   constructor(

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -1,5 +1,5 @@
 <div class="mypage">
-  <ng-container *ngIf="user$ | async as user">
+  <ng-container *ngIf="user$ | async as user; else notFoundUser">
     <div class="mypage__author">
       <img [src]="user.avatarURL" class="mypage__user-icon" alt="プロフィール画像">
       <div class="mypage__user-profile">
@@ -45,7 +45,7 @@
     </mat-tab-group>
   </ng-container>
 
-  <ng-container *ngIf="isNotFoundUser">
-    <p class="error">「{{screenName}}」というユーザーは存在しませんでした。</p>
-  </ng-container>
+  <ng-template #notFoundUser>
+    <p class="error" *ngIf="!isLoading">「{{screenName}}」というユーザーは存在しませんでした。</p>
+  </ng-template>
 </div>

--- a/src/app/mypage/mypage/mypage.component.html
+++ b/src/app/mypage/mypage/mypage.component.html
@@ -3,7 +3,14 @@
     <div class="mypage__author">
       <img [src]="user.avatarURL" class="mypage__user-icon" alt="プロフィール画像">
       <div class="mypage__user-profile">
-        <h2 class="mypage__user-name">{{user.userName}}</h2>
+        <div class="mypage__user-header">
+          <h2 class="mypage__user-name">{{user.userName}}</h2>
+          <ng-container *ngIf="isAuthor(user.uid)">
+            <div class="edit-profile">
+              <button mat-stroked-button class="edit-profile" routerLink="/settings">編集</button>
+            </div>
+          </ng-container>
+        </div>
         <p class="mypage__user-screen-name">@{{user.screenName}}</p>
         <p class="mypage__user-description" [innerHTML]="stringToLink(user.description)"></p>
         <a [href]="'https://twitter.com/' + user.screenName" class="mypage__twitter-icon">

--- a/src/app/mypage/mypage/mypage.component.scss
+++ b/src/app/mypage/mypage/mypage.component.scss
@@ -12,6 +12,10 @@
     padding-left: 32px;
     max-width: 460px;
   }
+  &__user-header {
+    display: flex;
+    align-items: center;
+  }
   &__user-icon {
     width: 120px;
     height: 120px;
@@ -19,7 +23,7 @@
   }
   &__user-name {
     font-weight: bold;
-    padding: 8px;
+    padding: 8px 0;
     margin: 0;
   }
   &__user-screen-name {
@@ -46,6 +50,10 @@
     justify-content: center;
     grid-column-gap: 12px;
   }
+}
+
+.edit-profile {
+  margin-left: auto;
 }
 
 .mat-tab-label {

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -19,7 +19,7 @@ export class MypageComponent implements OnInit {
   screenName: string;
   articles$: Observable<ArticleWithAuthor[]>;
 
-  isNotFoundUser: boolean;
+  isLoading: boolean;
 
   constructor(
     private route: ActivatedRoute,
@@ -28,15 +28,20 @@ export class MypageComponent implements OnInit {
     private loadingService: LoadingService,
   ) {
     this.loadingService.toggleLoading(true);
+    this.isLoading = true;
     this.route.paramMap.subscribe(params => {
       this.screenName = params.get('id');
       this.user$ = this.userService.getUserByScreenName(this.screenName).pipe(
-        tap(() => this.loadingService.toggleLoading(false),
-          catchError(err => of(null).pipe(tap(() => {
-            this.loadingService.toggleLoading(false);
-            this.isNotFoundUser = true;
-          })),
-          )));
+        tap(() => {
+          this.loadingService.toggleLoading(false);
+          this.isLoading = false;
+        }),
+        catchError((error) => {
+          this.loadingService.toggleLoading(false);
+          this.isLoading = false;
+          return of(null);
+        })
+      );
       let author: UserData;
       this.articles$ = this.user$.pipe(
         map((user: UserData) => {

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -37,6 +37,7 @@ export class MypageComponent implements OnInit {
           this.isLoading = false;
         }),
         catchError((error) => {
+          console.log(error.message);
           this.loadingService.toggleLoading(false);
           this.isLoading = false;
           return of(null);

--- a/src/app/mypage/mypage/mypage.component.ts
+++ b/src/app/mypage/mypage/mypage.component.ts
@@ -8,6 +8,7 @@ import { UserData } from 'functions/src/interfaces/user';
 import { ArticleWithAuthor } from 'functions/src/interfaces/article-with-author';
 import { Article } from 'functions/src/interfaces/article';
 import { LoadingService } from 'src/app/services/loading.service';
+import { AuthService } from 'src/app/services/auth.service';
 
 @Component({
   selector: 'app-mypage',
@@ -24,6 +25,7 @@ export class MypageComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private userService: UserService,
+    private authService: AuthService,
     private articleService: ArticleService,
     private loadingService: LoadingService,
   ) {
@@ -70,6 +72,14 @@ export class MypageComponent implements OnInit {
     const toATag = '<a href=\'$1\' target=\'_blank\'>$1</a>';
     const link = description.replace(linkReg, toATag);
     return link;
+  }
+
+  isAuthor(uid: string) {
+    if (uid === this.authService.uid) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   ngOnInit(): void {

--- a/src/app/mypage/note/note.component.html
+++ b/src/app/mypage/note/note.component.html
@@ -39,6 +39,8 @@
           <p class="note-header__updated-date">
             {{ article.createdAt.toDate() | date: 'yyyy年MM月dd日' }}更新
           </p>
+          <app-note-edit-buttons class="note-header__actions" *ngIf="isAuthor(article.author)" [article]="article">
+          </app-note-edit-buttons>
         </div>
         <h1 class="note-header__title">{{article.title}}
         </h1>

--- a/src/app/mypage/note/note.component.html
+++ b/src/app/mypage/note/note.component.html
@@ -1,4 +1,4 @@
-<ng-container *ngIf="article$ | async as article">
+<ng-container *ngIf="article$ | async as article; else notFoundArticle">
   <div class="note">
     <div class="note__left-box">
       <div class="left-actions">
@@ -21,6 +21,11 @@
     </div>
     <div class="note__main-box">
       <div class="note-header">
+        <div *ngIf="(article.isPublic === false)">
+          <div class="note-header__draft">
+            <div class="note-header__draft-text">これは公開前の下書きです</div>
+          </div>
+        </div>
         <div class="note-header__author">
           <a [routerLink]="'/'  + article.author.screenName">
             <img class="note-header__user-icon" [src]="article.author.avatarURL" alt="プロフィール画像"></a>
@@ -92,6 +97,6 @@
   </div>
 </ng-container>
 
-<ng-container *ngIf="isNotFoundArticle">
-  <p class="error">「{{articleId}}」という記事は存在しませんでした。</p>
-</ng-container>
+<ng-template #notFoundArticle>
+  <p class="error" *ngIf="!isLoading">「{{articleId}}」という記事は存在しませんでした。</p>
+</ng-template>

--- a/src/app/mypage/note/note.component.scss
+++ b/src/app/mypage/note/note.component.scss
@@ -61,6 +61,14 @@
 
 .note-header {
   padding: 0 4px;
+  &__draft {
+    background-color: #f0f0f0;
+    padding: 32px 0;
+    margin: 0 auto;
+  }
+  &__draft-text {
+    text-align: center;
+  }
   &__author {
     padding: 4px;
     display: flex;

--- a/src/app/mypage/note/note.component.scss
+++ b/src/app/mypage/note/note.component.scss
@@ -91,6 +91,9 @@
     color: #808080;
     margin: 0;
   }
+  &__actions {
+    margin-left: auto;
+  }
   &__title {
     padding: 0 4px;
   }

--- a/src/app/mypage/note/note.component.ts
+++ b/src/app/mypage/note/note.component.ts
@@ -77,6 +77,7 @@ export class NoteComponent implements OnInit {
           this.isLoading = false;
         }),
         catchError((error) => {
+          console.log(error.message);
           this.loadingService.toggleLoading(false);
           this.isLoading = false;
           return of(null);

--- a/src/app/mypage/note/note.component.ts
+++ b/src/app/mypage/note/note.component.ts
@@ -24,7 +24,7 @@ export class NoteComponent implements OnInit {
   headingPositions: number[] = [];
   headingElements: Element[] = [];
 
-  isNotFoundArticle: boolean;
+  isLoading: boolean;
 
   @HostListener('window:scroll', ['$event'])
   getTableOfContents() {
@@ -47,6 +47,7 @@ export class NoteComponent implements OnInit {
     private loadingService: LoadingService,
   ) {
     this.loadingService.toggleLoading(true);
+    this.isLoading = true;
     this.route.paramMap.subscribe(params => {
       this.articleId = params.get('id');
       const post$ = this.articleService.getArticleOnly(this.articleId);
@@ -71,12 +72,15 @@ export class NoteComponent implements OnInit {
           }
         }),
         tap(() => this.getHeading()),
-        tap(() => this.loadingService.toggleLoading(false)),
-        catchError(err => of(null).pipe(tap(() => {
+        tap(() => {
           this.loadingService.toggleLoading(false);
-          this.isNotFoundArticle = true;
-        })),
-        )
+          this.isLoading = false;
+        }),
+        catchError((error) => {
+          this.loadingService.toggleLoading(false);
+          this.isLoading = false;
+          return of(null);
+        })
       );
     });
   }

--- a/src/app/mypage/note/note.component.ts
+++ b/src/app/mypage/note/note.component.ts
@@ -113,9 +113,21 @@ export class NoteComponent implements OnInit {
 
   stringToLink(description: string): string {
     const linkReg = new RegExp(/(http(s)?:\/\/[a-zA-Z0-9-.!'()*;/?:@&=+$,%#]+)/gi);
-    const toATag = '<a href=\'$1\' target=\'_blank\'>$1</a>';
-    const link = description.replace(linkReg, toATag);
-    return link;
+    if (linkReg.test(description)) {
+      const toATag = '<a href=\'$1\' target=\'_blank\'>$1</a>';
+      const link = description.replace(linkReg, toATag);
+      return link;
+    } else {
+      return description;
+    }
+  }
+
+  isAuthor(author: UserData) {
+    if (author.uid === this.authService.uid) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   ngOnInit(): void {

--- a/src/app/notes/notes.module.ts
+++ b/src/app/notes/notes.module.ts
@@ -11,7 +11,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { FroalaEditorModule } from 'angular-froala-wysiwyg';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
-import { MatMenuModule } from '@angular/material/menu';
 import { SharedModule } from '../shared/shared.module';
 
 @NgModule({
@@ -27,7 +26,6 @@ import { SharedModule } from '../shared/shared.module';
     FroalaEditorModule,
     MatSlideToggleModule,
     MatIconModule,
-    MatMenuModule,
     SharedModule,
   ],
 })

--- a/src/app/notes/notes/notes.component.html
+++ b/src/app/notes/notes/notes.component.html
@@ -20,24 +20,7 @@
               </p>
             </div>
           </a>
-          <div class="list-item__actions">
-            <button mat-stroked-button class="list-item__edit"
-              [routerLink]="'/notes/' + article.articleId + '/edit'">編集</button>
-            <button mat-icon-button [matMenuTriggerFor]="noteAction" aria-label="ノートのアクション" class="list-item__others">
-              <mat-icon>more_horiz</mat-icon>
-            </button>
-
-            <mat-menu #noteAction="matMenu">
-              <button mat-menu-item>
-                <mat-icon>link</mat-icon>
-                <span>共有リンクを取得</span>
-              </button>
-              <button mat-menu-item class="delete" (click)="openDeleteDialog(article)">
-                <mat-icon>delete_forever</mat-icon>
-                <span>削除</span>
-              </button>
-            </mat-menu>
-          </div>
+          <app-note-edit-buttons *ngIf="article" [article]="article"></app-note-edit-buttons>
         </div>
       </div>
     </ng-container>

--- a/src/app/notes/notes/notes.component.scss
+++ b/src/app/notes/notes/notes.component.scss
@@ -76,7 +76,3 @@
 .no-article {
   text-align: center;
 }
-
-.delete {
-  color: red;
-}

--- a/src/app/notes/notes/notes.component.ts
+++ b/src/app/notes/notes/notes.component.ts
@@ -1,10 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ArticleService } from 'src/app/services/article.service';
-import { UserService } from 'src/app/services/user.service';
 import { Observable } from 'rxjs';
 import { AuthService } from 'src/app/services/auth.service';
-import { MatDialog } from '@angular/material/dialog';
-import { DeleteDialogComponent } from 'src/app/shared/delete-dialog/delete-dialog.component';
 import { Article } from 'functions/src/interfaces/article';
 import { UserData } from 'functions/src/interfaces/user';
 import { LoadingService } from 'src/app/services/loading.service';
@@ -17,30 +14,20 @@ import { tap } from 'rxjs/operators';
 })
 export class NotesComponent implements OnInit {
   uid = this.authService.uid;
+  user$: Observable<UserData> = this.authService.user$;
   articles$: Observable<Article[]> = this.articleService.getMyArticles(this.uid).pipe(
     tap(() => this.loadingService.toggleLoading(false))
   );
-  user$: Observable<UserData> = this.userService.getUserData(this.uid);
 
   constructor(
     private articleService: ArticleService,
     private authService: AuthService,
-    private userService: UserService,
-    private dialog: MatDialog,
     private loadingService: LoadingService,
   ) {
     this.loadingService.toggleLoading(true);
   }
 
   ngOnInit(): void {
-  }
-
-  openDeleteDialog(article: Article) {
-    this.dialog.open(DeleteDialogComponent, {
-      autoFocus: false,
-      restoreFocus: false,
-      data: article,
-    });
   }
 
 }

--- a/src/app/search-input/search-input.component.html
+++ b/src/app/search-input/search-input.component.html
@@ -2,8 +2,8 @@
   <input type="text" placeholder="キーワードを入力" aria-label="キーワード" autocomplete="off" matInput [formControl]="searchControl"
     [matAutocomplete]="search" class="search__input" />
   <mat-autocomplete #search="matAutocomplete">
-    <mat-option *ngFor="let option of searchResult?.hits" [value]="option.title" (click)="routeSearch(option.title)">
-      {{option.title}}
+    <mat-option *ngFor="let option of searchResult?.hits" [value]="option.title">
+      <div class="search__input-item" (click)="routeSearch(option.title)">{{option.title}}</div>
     </mat-option>
   </mat-autocomplete>
   <button mat-icon-button color="white" aria-label="検索アイコン" class="search__button">

--- a/src/app/search-input/search-input.component.html
+++ b/src/app/search-input/search-input.component.html
@@ -2,7 +2,7 @@
   <input type="text" placeholder="キーワードを入力" aria-label="キーワード" autocomplete="off" matInput [formControl]="searchControl"
     [matAutocomplete]="search" class="search__input" />
   <mat-autocomplete #search="matAutocomplete">
-    <mat-option *ngFor="let option of searchResult?.hits" [value]="option.title">
+    <mat-option *ngFor="let option of searchResult?.hits" [value]="option.title" (click)="routeSearch(option.title)">
       {{option.title}}
     </mat-option>
   </mat-autocomplete>

--- a/src/app/search-input/search-input.component.ts
+++ b/src/app/search-input/search-input.component.ts
@@ -19,7 +19,8 @@ export class SearchInputComponent implements OnInit {
   };
   searchOptions = {
     page: 0,
-    hitsPerPage: 20,
+    hitsPerPage: 8,
+    facetFilters: ['isPublic:true']
   };
 
   isSearchActive: boolean;
@@ -61,7 +62,7 @@ export class SearchInputComponent implements OnInit {
       .pipe(startWith(''))
       .subscribe((keyword) => {
         const searchKeyword: string = keyword;
-        this.index.search(searchKeyword)
+        this.index.search(searchKeyword, this.searchOptions)
           .then((searchResult) => this.searchResult = searchResult);
       });
   }

--- a/src/app/search-result/search-result.component.ts
+++ b/src/app/search-result/search-result.component.ts
@@ -24,6 +24,7 @@ export class SearchResultComponent implements OnInit {
   searchOptions = {
     page: 0,
     hitsPerPage: 20,
+    facetFilters: ['isPublic:true']
   };
 
   articles$: Observable<ArticleWithAuthor[]>;
@@ -37,7 +38,7 @@ export class SearchResultComponent implements OnInit {
     this.loadingService.toggleLoading(true);
     this.route.queryParamMap.subscribe((params) => {
       this.searchQuery = params.get('q');
-      this.index.search(this.searchQuery).then((searchResult) => this.searchResult = searchResult)
+      this.index.search(this.searchQuery, this.searchOptions).then((searchResult) => this.searchResult = searchResult)
         .then(() => {
           if (this.searchResult.hits) {
             const algoriaItemIds: string[] = this.searchResult.hits.map(algoriaItem => algoriaItem.articleId);

--- a/src/app/search-result/search-result.component.ts
+++ b/src/app/search-result/search-result.component.ts
@@ -47,10 +47,11 @@ export class SearchResultComponent implements OnInit {
                 return articles.filter((article: Article) => algoriaItemIds.includes(article.articleId));
               }),
               tap(() => this.loadingService.toggleLoading(false)),
-              catchError(err => of(null).pipe(tap(() => {
+              catchError((error) => {
+                console.log(error.message);
                 this.loadingService.toggleLoading(false);
-              })),
-              )
+                return of(null);
+              })
             );
           }
         });

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -87,7 +87,7 @@ export class ArticleService {
           };
           return result;
         });
-      })
+      }),
     );
   }
 }

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -37,8 +37,7 @@ export class AuthService {
       await this.afAuth.signOut();
     }
     if (this.uid) {
-      const provider = new auth.TwitterAuthProvider();
-      return await this.afAuth.signInWithPopup(provider)
+      return await this.userService.updateUser()
         .then(() => {
           this.router.navigateByUrl('/');
           this.snackBar.open('ログインしました。', '閉じる', { duration: 5000 });

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -32,33 +32,46 @@ export class AuthService {
     private userService: UserService,
   ) { }
 
-  login(): Promise<void> {
-    const provider = new auth.TwitterAuthProvider();
-    return this.afAuth.signInWithPopup(provider)
-      .then((userCredential) => {
-        const user = userCredential.user;
-        const userInfo = userCredential.additionalUserInfo.profile;
-        const userInfoObj = JSON.parse(JSON.stringify(userInfo));
-        const avatarURL = userInfoObj.profile_image_url_https.replace('_normal', '');
-        this.userService.updateUser({
-          uid: user.uid,
-          userName: userInfoObj.name,
-          avatarURL,
-          screenName: userInfoObj.screen_name,
-          description: userInfoObj.description,
+  async login(): Promise<void> {
+    if (this.afUser$) {
+      await this.afAuth.signOut();
+    }
+    if (this.uid) {
+      const provider = new auth.TwitterAuthProvider();
+      return await this.afAuth.signInWithPopup(provider)
+        .then(() => {
+          this.router.navigateByUrl('/');
+          this.snackBar.open('ログインしました。', '閉じる', { duration: 5000 });
+        })
+        .catch((error) => {
+          this.router.navigateByUrl('/');
+          console.log(error.message);
+          this.snackBar.open('ログインエラーです。数秒後にもう一度お試しください。', '閉じる', { duration: 5000 });
         });
+    } else {
+      return await this.userService.createUser()
+        .then(() => {
+          this.router.navigateByUrl('/');
+          this.snackBar.open('ログインしました。', '閉じる', { duration: 5000 });
+        })
+        .catch((error) => {
+          this.router.navigateByUrl('/');
+          console.log(error.message);
+          this.snackBar.open('ログインエラーです。数秒後にもう一度お試しください。', '閉じる', { duration: 5000 });
+        });
+    }
+  }
+
+  logout() {
+    this.afAuth.signOut()
+      .then(() => {
+        this.router.navigateByUrl('/');
+        this.snackBar.open('ログアウトしました。', '閉じる', { duration: 5000 });
       })
       .catch((error) => {
         this.router.navigateByUrl('/');
         console.log(error.message);
-        this.snackBar.open('ログインエラーです。数秒後にもう一度お試しください。', '閉じる', { duration: 5000 });
+        this.snackBar.open('ログアウトエラーです。数秒後にもう一度お試しください。', '閉じる', { duration: 5000 });
       });
-  }
-
-  logout() {
-    this.afAuth.signOut().then(() => {
-      this.router.navigateByUrl('/');
-      this.snackBar.open('ログアウトしました。', '閉じる', { duration: 5000 });
-    });
   }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -52,6 +52,17 @@ export class UserService {
     return this.db.doc<UserData>(`users/${user.uid}`).set(userData);
   }
 
+  async updateUser(): Promise<void> {
+    const provider = new auth.TwitterAuthProvider();
+    const userCredential = await this.afAuth.signInWithPopup(provider);
+    const { user, additionalUserInfo } = userCredential;
+    const userProfObj = JSON.parse(JSON.stringify(additionalUserInfo.profile));
+    const userData: Pick<UserData, 'screenName'> = {
+      screenName: userProfObj.screen_name,
+    };
+    return this.db.doc<UserData>(`users/${user.uid}`).update(userData);
+  }
+
   async uploadAvatar(uid: string, avatar: string): Promise<void> {
     const time: number = new Date().getTime();
     const result = await this.storage.ref(`users/${uid}/avatar/${time}`).putString(avatar, 'data_url');
@@ -59,7 +70,7 @@ export class UserService {
     return this.db.doc<UserData>(`users/${uid}`).update({ avatarURL });
   }
 
-  changeUserData(uid: string, newUserData: Omit<UserData, 'uid' | 'avatarURL' | 'screenName'>): Promise<void> {
+  changeUserData(uid: string, newUserData: Pick<UserData, 'userName' | 'description'>): Promise<void> {
     return this.db.doc<UserData>(`users/${uid}`).update(newUserData);
   }
 

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -59,6 +59,10 @@ export class UserService {
     return this.db.doc<UserData>(`users/${uid}`).update({ avatarURL });
   }
 
+  changeUserData(uid: string, newUserData: Omit<UserData, 'uid' | 'avatarURL' | 'screenName'>): Promise<void> {
+    return this.db.doc<UserData>(`users/${uid}`).update(newUserData);
+  }
+
   async deleteUser(): Promise<void> {
     return (await this.afAuth.currentUser).delete();
   }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -5,6 +5,7 @@ import { map } from 'rxjs/operators';
 import { AngularFireAuth } from '@angular/fire/auth';
 import { UserData } from 'functions/src/interfaces/user';
 import { auth } from 'firebase/app';
+import { AngularFireStorage } from '@angular/fire/storage';
 
 @Injectable({
   providedIn: 'root'
@@ -14,6 +15,7 @@ export class UserService {
   constructor(
     private db: AngularFirestore,
     private afAuth: AngularFireAuth,
+    private storage: AngularFireStorage,
   ) { }
 
   getUserData(uid: string): Observable<UserData> {
@@ -48,6 +50,13 @@ export class UserService {
       description: userProfObj.description,
     };
     return this.db.doc<UserData>(`users/${user.uid}`).set(userData);
+  }
+
+  async uploadAvatar(uid: string, avatar: string): Promise<void> {
+    const time: number = new Date().getTime();
+    const result = await this.storage.ref(`users/${uid}/avatar/${time}`).putString(avatar, 'data_url');
+    const avatarURL = await result.ref.getDownloadURL();
+    return this.db.doc<UserData>(`users/${uid}`).update({ avatarURL });
   }
 
   async deleteUser(): Promise<void> {

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AngularFireAuth } from '@angular/fire/auth';
 import { UserData } from 'functions/src/interfaces/user';
+import { auth } from 'firebase/app';
 
 @Injectable({
   providedIn: 'root'
@@ -34,8 +35,19 @@ export class UserService {
       );
   }
 
-  updateUser(userData: UserData): Promise<void> {
-    return this.db.doc<UserData>(`users/${userData.uid}`).set(userData);
+  async createUser(): Promise<void> {
+    const provider = new auth.TwitterAuthProvider();
+    const userCredential = await this.afAuth.signInWithPopup(provider);
+    const { user, additionalUserInfo } = userCredential;
+    const userProfObj = JSON.parse(JSON.stringify(additionalUserInfo.profile));
+    const userData: UserData = {
+      uid: user.uid,
+      userName: userProfObj.name,
+      avatarURL: userProfObj.profile_image_url_https.replace('_normal', ''),
+      screenName: userProfObj.screen_name,
+      description: userProfObj.description,
+    };
+    return this.db.doc<UserData>(`users/${user.uid}`).set(userData);
   }
 
   async deleteUser(): Promise<void> {

--- a/src/app/settings/delete-account-dialog/delete-account-dialog.component.html
+++ b/src/app/settings/delete-account-dialog/delete-account-dialog.component.html
@@ -1,0 +1,11 @@
+<h2 mat-dialog-title>退会</h2>
+<mat-dialog-content>
+  <p>すべてのデータが削除されます。よろしいですか？</p>
+  <p>※削除されたデータはもとに戻すことはできません。</p>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button mat-dialog-close>キャンセル</button>
+  <button mat-flat-button color="warn" (click)="deleteAccount()">
+    退会する
+  </button>
+</mat-dialog-actions>

--- a/src/app/settings/delete-account-dialog/delete-account-dialog.component.scss
+++ b/src/app/settings/delete-account-dialog/delete-account-dialog.component.scss
@@ -1,0 +1,11 @@
+.mat-dialog-title {
+  text-align: center;
+}
+.mat-dialog-content {
+  p {
+    margin: 0;
+  }
+}
+.mat-dialog-actions {
+  justify-content: flex-end;
+}

--- a/src/app/settings/delete-account-dialog/delete-account-dialog.component.spec.ts
+++ b/src/app/settings/delete-account-dialog/delete-account-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DeleteAccountDialogComponent } from './delete-account-dialog.component';
+
+describe('DeleteAccountDialogComponent', () => {
+  let component: DeleteAccountDialogComponent;
+  let fixture: ComponentFixture<DeleteAccountDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ DeleteAccountDialogComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DeleteAccountDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/settings/delete-account-dialog/delete-account-dialog.component.ts
+++ b/src/app/settings/delete-account-dialog/delete-account-dialog.component.ts
@@ -1,0 +1,38 @@
+import { Component, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { UserService } from 'src/app/services/user.service';
+import { AuthService } from 'src/app/services/auth.service';
+import { MatDialogRef } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-delete-account-dialog',
+  templateUrl: './delete-account-dialog.component.html',
+  styleUrls: ['./delete-account-dialog.component.scss']
+})
+export class DeleteAccountDialogComponent implements OnInit {
+
+  constructor(
+    private snackBar: MatSnackBar,
+    private userService: UserService,
+    private authService: AuthService,
+    private router: Router,
+    private dialogRef: MatDialogRef<DeleteAccountDialogComponent>,
+  ) {
+  }
+
+  ngOnInit(): void {
+  }
+
+  deleteAccount() {
+    this.dialogRef.close();
+    this.userService.deleteUser()
+      .then(() => {
+        this.router.navigateByUrl('/');
+        this.snackBar.open('アカウントが削除されました。ご利用ありがとうございました。', '閉じる', { duration: 5000 });
+      })
+      .catch(() => {
+        this.snackBar.open('削除に失敗しました。再度ログインしてお試しください。', '閉じる', { duration: 5000 });
+      });
+  }
+}

--- a/src/app/settings/image-crop-dialog/image-crop-dialog.component.html
+++ b/src/app/settings/image-crop-dialog/image-crop-dialog.component.html
@@ -1,0 +1,18 @@
+<image-cropper [imageChangedEvent]="imageChangedEvent" [maintainAspectRatio]="true" [aspectRatio]="1 / 1" format="png"
+  resizeToWidth="300" (imageCropped)="imageCropped($event)" (loadImageFailed)="loadImageFailed()">
+</image-cropper>
+<ng-container *ngIf="croppedImage; else loading">
+  <img [src]="croppedImage" class="avatar-image" alt="プロフィール画像">
+</ng-container>
+<ng-template #loading>
+  <mat-spinner class="loading-bar" diameter="100" strokeWidth="8"></mat-spinner>
+</ng-template>
+<div class="actions">
+  <button class="actions__cancel-button" *ngIf="imageChangedEvent" mat-button (click)="resetInput()">
+    キャンセル
+  </button>
+  <button class="actions__change-button" [disabled]="!croppedImage" (click)="changeAvatar()" mat-flat-button
+    color="primary">
+    変更する
+  </button>
+</div>

--- a/src/app/settings/image-crop-dialog/image-crop-dialog.component.scss
+++ b/src/app/settings/image-crop-dialog/image-crop-dialog.component.scss
@@ -1,0 +1,22 @@
+image-cropper {
+  display: block;
+  margin: 12px auto;
+  width: 300px;
+}
+
+.avatar-image {
+  margin: 0 auto;
+  display: block;
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  margin-bottom: 16px;
+}
+
+.actions {
+  display: flex;
+  justify-content: space-around;
+  &__cancel-button {
+    margin-right: 12px;
+  }
+}

--- a/src/app/settings/image-crop-dialog/image-crop-dialog.component.spec.ts
+++ b/src/app/settings/image-crop-dialog/image-crop-dialog.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ImageCropDialogComponent } from './image-crop-dialog.component';
+
+describe('ImageCropDialogComponent', () => {
+  let component: ImageCropDialogComponent;
+  let fixture: ComponentFixture<ImageCropDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ImageCropDialogComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ImageCropDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/settings/image-crop-dialog/image-crop-dialog.component.ts
+++ b/src/app/settings/image-crop-dialog/image-crop-dialog.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ImageCroppedEvent } from 'ngx-image-cropper';
+import { UserService } from 'src/app/services/user.service';
+import { AuthService } from 'src/app/services/auth.service';
+
+@Component({
+  selector: 'app-image-crop-dialog',
+  templateUrl: './image-crop-dialog.component.html',
+  styleUrls: ['./image-crop-dialog.component.scss']
+})
+export class ImageCropDialogComponent implements OnInit {
+  imageChangedEvent = '';
+  croppedImage = '';
+  imageSelecter: any;
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: { event: any, imageSelecter: any },
+    private snackBar: MatSnackBar,
+    private dialogRef: MatDialogRef<ImageCropDialogComponent>,
+    private userService: UserService,
+    private authService: AuthService,
+  ) {
+    this.imageChangedEvent = this.data.event;
+    this.imageSelecter = this.data.imageSelecter;
+  }
+
+  ngOnInit(): void {
+  }
+
+  imageCropped(event: ImageCroppedEvent) {
+    this.croppedImage = event.base64;
+  }
+
+  loadImageFailed() {
+    this.dialogRef.close();
+    this.snackBar.open('画像の読み込みに失敗しました', '閉じる', { duration: 5000 });
+  }
+
+  resetInput() {
+    this.imageChangedEvent = '';
+    this.imageSelecter.value = '';
+    this.dialogRef.close();
+  }
+
+  changeAvatar() {
+    if (this.croppedImage) {
+      this.dialogRef.close();
+      this.userService.uploadAvatar(this.authService.uid, this.croppedImage)
+        .then(() => {
+          this.imageChangedEvent = '';
+          this.imageSelecter.value = '';
+          this.snackBar.open('画像を変更しました。', '閉じる', { duration: 5000 });
+        });
+    }
+  }
+}

--- a/src/app/settings/settings-routing.module.ts
+++ b/src/app/settings/settings-routing.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { SettingsComponent } from './settings/settings.component';
+
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: SettingsComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class SettingsRoutingModule { }

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -12,9 +12,11 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { ImageCropperModule } from 'ngx-image-cropper';
 import { ImageCropDialogComponent } from './image-crop-dialog/image-crop-dialog.component';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { DeleteAccountDialogComponent } from './delete-account-dialog/delete-account-dialog.component';
+import { MatDialogModule } from '@angular/material/dialog';
 
 @NgModule({
-  declarations: [SettingsComponent, ImageCropDialogComponent],
+  declarations: [SettingsComponent, ImageCropDialogComponent, DeleteAccountDialogComponent],
   imports: [
     CommonModule,
     SettingsRoutingModule,
@@ -27,6 +29,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
     MatButtonModule,
     ImageCropperModule,
     MatProgressSpinnerModule,
+    MatDialogModule
   ]
 })
 export class SettingsModule { }

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { SettingsRoutingModule } from './settings-routing.module';
+import { SettingsComponent } from './settings/settings.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatInputModule } from '@angular/material/input';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { ImageCropperModule } from 'ngx-image-cropper';
+import { ImageCropDialogComponent } from './image-crop-dialog/image-crop-dialog.component';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@NgModule({
+  declarations: [SettingsComponent, ImageCropDialogComponent],
+  imports: [
+    CommonModule,
+    SettingsRoutingModule,
+    MatIconModule,
+    MatTabsModule,
+    ReactiveFormsModule,
+    FormsModule,
+    MatInputModule,
+    MatFormFieldModule,
+    MatButtonModule,
+    ImageCropperModule,
+    MatProgressSpinnerModule,
+  ]
+})
+export class SettingsModule { }

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -1,0 +1,41 @@
+<div class="settings">
+  <h1 class="settings__title">設定</h1>
+  <ng-container *ngIf="user$ | async as user">
+    <h2 class="settings__heading">プロフィール</h2>
+    <form class="settings__profile-form" [formGroup]="form">
+      <label for="avatarFile" [style.background-image]="'url(' + form.value.avatarURL + ')'"
+        class="settings__avatar-image" alt="プロフィール画像">
+        <div class="settings__avatar-icon-wrap">
+          <mat-icon class="settings__avatar-icon">add_a_photo</mat-icon>
+        </div>
+      </label>
+      <input id="avatarFile" type="file" accept="image/*" class="settings__avatar-input"
+        (change)="openImageCropDialog($event, imageSelecter)" #imageSelecter>
+      <mat-form-field class="settings__user-name" appearance="outline">
+        <mat-label>ユーザー名*</mat-label>
+        <input type="text" formControlName="userName" matInput placeholder="ユーザー名*" autocomplete="off" />
+        <mat-error *ngIf="userNameControl.hasError('required')">必須項目です</mat-error>
+        <mat-error *ngIf="userNameControl.hasError('maxlength')">50文字以内にしてください</mat-error>
+      </mat-form-field>
+      <div class="settings__screen-name">
+        <span class="settings__screen-name-label">スクリーンネーム(Twitterアカウントに紐付いています)</span>
+        <div class="settings__screen-name-text">@{{user.screenName}}</div>
+      </div>
+      <mat-form-field class="settings__description" appearance="outline">
+        <mat-label>自己紹介</mat-label>
+        <textarea type="text" formControlName="description" matInput placeholder="自己紹介" autocomplete="off"
+          class="settings__description-text"></textarea>
+        <mat-error *ngIf="descriptionControl.hasError('maxlength')">160文字以内にしてください</mat-error>
+      </mat-form-field>
+      <button [disabled]="form.invalid || form.pristine" class="save-button" mat-flat-button color="primary"
+        (click)="saveProfile()">
+        プロフィールを更新
+      </button>
+    </form>
+
+    <h2 class="settings__heading">退会</h2>
+    <p>退会するとすべてのデータが削除され、復元できません。</p>
+    <button class="delete-account-button" mat-flat-button color="primary" (click)="deleteAccount()">
+    </button>
+  </ng-container>
+</div>

--- a/src/app/settings/settings/settings.component.html
+++ b/src/app/settings/settings/settings.component.html
@@ -3,8 +3,8 @@
   <ng-container *ngIf="user$ | async as user">
     <h2 class="settings__heading">プロフィール</h2>
     <form class="settings__profile-form" [formGroup]="form">
-      <label for="avatarFile" [style.background-image]="'url(' + form.value.avatarURL + ')'"
-        class="settings__avatar-image" alt="プロフィール画像">
+      <label for="avatarFile" [style.background-image]="'url(' + user.avatarURL + ')'" class="settings__avatar-image"
+        alt="プロフィール画像">
         <div class="settings__avatar-icon-wrap">
           <mat-icon class="settings__avatar-icon">add_a_photo</mat-icon>
         </div>
@@ -28,14 +28,14 @@
         <mat-error *ngIf="descriptionControl.hasError('maxlength')">160文字以内にしてください</mat-error>
       </mat-form-field>
       <button [disabled]="form.invalid || form.pristine" class="save-button" mat-flat-button color="primary"
-        (click)="saveProfile()">
+        (click)="changeProfile()">
         プロフィールを更新
       </button>
     </form>
 
     <h2 class="settings__heading">退会</h2>
     <p>退会するとすべてのデータが削除され、復元できません。</p>
-    <button class="delete-account-button" mat-flat-button color="primary" (click)="deleteAccount()">
-    </button>
+    <button class="delete-account-button" mat-flat-button color="warn" (click)="openDeleteAccountDialog()">
+      退会する</button>
   </ng-container>
 </div>

--- a/src/app/settings/settings/settings.component.scss
+++ b/src/app/settings/settings/settings.component.scss
@@ -74,6 +74,14 @@
   display: block;
   margin-left: auto;
   margin-bottom: 12px;
+  background-color: #ff5500;
+  font-weight: bold;
+}
+
+.delete-account-button {
+  display: block;
+  margin-left: auto;
+  margin-bottom: 12px;
 }
 
 :host {

--- a/src/app/settings/settings/settings.component.scss
+++ b/src/app/settings/settings/settings.component.scss
@@ -1,0 +1,83 @@
+.settings {
+  padding: 12px;
+  margin: 0 auto;
+  max-width: 600px;
+  &__title {
+    font-size: 20px;
+    margin-bottom: 24px;
+    font-weight: bold;
+  }
+  &__heading {
+    font-size: 18px;
+    font-weight: bold;
+  }
+  &__avatar-image {
+    position: relative;
+    margin: 0 auto;
+    display: block;
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    background-size: cover;
+    background-position: center;
+    margin-bottom: 16px;
+    cursor: pointer;
+  }
+  &__avatar-icon-wrap {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: rgba(45, 45, 45, 0.5);
+    border-radius: 50%;
+    &:hover {
+      background: rgba(45, 45, 45, 0.8);
+      transition-duration: 0.2s;
+    }
+  }
+  &__avatar-icon {
+    color: #ffffff;
+  }
+  &__avatar-input {
+    display: none;
+  }
+  &__user-name {
+    font-weight: bold;
+    width: 100%;
+  }
+  &__screen-name {
+    margin-bottom: 16px;
+    width: 100%;
+  }
+  &__screen-name-label {
+    font-size: 12px;
+    padding-left: 12px;
+  }
+  &__screen-name-text {
+    font-weight: bold;
+    padding: 12px;
+  }
+  &__description {
+    width: 100%;
+  }
+  &__description-text {
+    resize: none;
+    height: 72px;
+  }
+}
+
+.save-button {
+  display: block;
+  margin-left: auto;
+  margin-bottom: 12px;
+}
+
+:host {
+  .mat-form-field {
+    margin-bottom: -10px;
+  }
+}

--- a/src/app/settings/settings/settings.component.spec.ts
+++ b/src/app/settings/settings/settings.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SettingsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/settings/settings/settings.component.ts
+++ b/src/app/settings/settings/settings.component.ts
@@ -1,0 +1,82 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Observable, Subscription } from 'rxjs';
+import { UserData } from '@interfaces/user';
+import { AuthService } from 'src/app/services/auth.service';
+import { LoadingService } from 'src/app/services/loading.service';
+import { FormControl, Validators, FormBuilder } from '@angular/forms';
+import { tap } from 'rxjs/operators';
+import { UserService } from 'src/app/services/user.service';
+import { MatDialog } from '@angular/material/dialog';
+import { ImageCropDialogComponent } from '../image-crop-dialog/image-crop-dialog.component';
+
+@Component({
+  selector: 'app-settings',
+  templateUrl: './settings.component.html',
+  styleUrls: ['./settings.component.scss']
+})
+export class SettingsComponent implements OnInit, OnDestroy {
+  uid = this.authService.uid;
+  user$: Observable<UserData> = this.authService.user$.pipe(
+    tap(() => this.loadingService.toggleLoading(false))
+  );
+
+  form = this.fb.group({
+    avatarURL: [''],
+    userName: ['', [Validators.required, Validators.maxLength(50)]],
+    description: ['', [Validators.maxLength(160)]],
+  });
+
+  get avatarURLControl() {
+    return this.form.get('avatarURL') as FormControl;
+  }
+
+  get userNameControl() {
+    return this.form.get('userName') as FormControl;
+  }
+
+  get descriptionControl() {
+    return this.form.get('description') as FormControl;
+  }
+
+  subscription: Subscription;
+
+  constructor(
+    private authService: AuthService,
+    private userService: UserService,
+    private loadingService: LoadingService,
+    private fb: FormBuilder,
+    private dialog: MatDialog,
+  ) {
+    this.loadingService.toggleLoading(true);
+    this.subscription = this.user$.subscribe((user: UserData) => {
+      this.form.patchValue({
+        avatarURL: user.avatarURL,
+        userName: user.userName,
+        description: user.description,
+      });
+    });
+  }
+
+  ngOnInit(): void {
+  }
+
+  openImageCropDialog(event: any, imageSelecter: any) {
+    this.dialog.open(ImageCropDialogComponent, {
+      autoFocus: false,
+      restoreFocus: false,
+      data: { event, imageSelecter },
+    });
+  }
+
+  saveProfile(): void {
+
+  }
+
+  deleteAccount(): void {
+
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
+  }
+}

--- a/src/app/settings/settings/settings.component.ts
+++ b/src/app/settings/settings/settings.component.ts
@@ -71,7 +71,7 @@ export class SettingsComponent implements OnInit, OnDestroy {
 
   changeProfile() {
     const formData = this.form.value;
-    const newUserData: Omit<UserData, 'uid' | 'avatarURL' | 'screenName'> = {
+    const newUserData: Pick<UserData, 'userName' | 'description'> = {
       userName: formData.userName,
       description: formData.description,
     };

--- a/src/app/shared/delete-dialog/delete-dialog.component.html
+++ b/src/app/shared/delete-dialog/delete-dialog.component.html
@@ -5,7 +5,7 @@
 </mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button mat-dialog-close>キャンセル</button>
-  <button mat-button color="warn" (click)="deleteArticle()">
+  <button mat-flat-button color="warn" (click)="deleteArticle()">
     削除
   </button>
 </mat-dialog-actions>

--- a/src/app/shared/delete-dialog/delete-dialog.component.ts
+++ b/src/app/shared/delete-dialog/delete-dialog.component.ts
@@ -3,6 +3,7 @@ import { ArticleService } from 'src/app/services/article.service';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Article } from 'functions/src/interfaces/article';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-delete-dialog',
@@ -16,6 +17,7 @@ export class DeleteDialogComponent implements OnInit {
     private articleService: ArticleService,
     private snackBar: MatSnackBar,
     private dialogRef: MatDialogRef<DeleteDialogComponent>,
+    private router: Router,
   ) { }
 
   ngOnInit(): void {
@@ -24,6 +26,7 @@ export class DeleteDialogComponent implements OnInit {
   deleteArticle() {
     this.dialogRef.close();
     this.articleService.deleteArticle(this.data.articleId).then(() => {
+      this.router.navigateByUrl('/');
       this.snackBar.open('削除しました。', '閉じる', { duration: 5000 });
     });
   }

--- a/src/app/shared/note-edit-buttons/note-edit-buttons.component.html
+++ b/src/app/shared/note-edit-buttons/note-edit-buttons.component.html
@@ -1,0 +1,15 @@
+<button mat-stroked-button class="edit" [routerLink]="'/notes/' + article.articleId + '/edit'">編集</button>
+<button mat-icon-button [matMenuTriggerFor]="noteAction" aria-label="ノートのアクション" class="others">
+  <mat-icon>more_horiz</mat-icon>
+</button>
+
+<mat-menu #noteAction="matMenu">
+  <button mat-menu-item>
+    <mat-icon>link</mat-icon>
+    <span>共有リンクを取得</span>
+  </button>
+  <button mat-menu-item class="delete" (click)="openDeleteDialog(article)">
+    <mat-icon>delete_forever</mat-icon>
+    <span>削除</span>
+  </button>
+</mat-menu>

--- a/src/app/shared/note-edit-buttons/note-edit-buttons.component.scss
+++ b/src/app/shared/note-edit-buttons/note-edit-buttons.component.scss
@@ -1,0 +1,3 @@
+.delete {
+  color: red;
+}

--- a/src/app/shared/note-edit-buttons/note-edit-buttons.component.spec.ts
+++ b/src/app/shared/note-edit-buttons/note-edit-buttons.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NoteEditButtonsComponent } from './note-edit-buttons.component';
+
+describe('NoteEditButtonsComponent', () => {
+  let component: NoteEditButtonsComponent;
+  let fixture: ComponentFixture<NoteEditButtonsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ NoteEditButtonsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NoteEditButtonsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/note-edit-buttons/note-edit-buttons.component.ts
+++ b/src/app/shared/note-edit-buttons/note-edit-buttons.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { DeleteDialogComponent } from 'src/app/shared/delete-dialog/delete-dialog.component';
+import { ArticleWithAuthor } from '@interfaces/article-with-author';
+import { Article } from '@interfaces/article';
+
+@Component({
+  selector: 'app-note-edit-buttons',
+  templateUrl: './note-edit-buttons.component.html',
+  styleUrls: ['./note-edit-buttons.component.scss']
+})
+export class NoteEditButtonsComponent implements OnInit {
+  @Input() article: Article | ArticleWithAuthor;
+
+  constructor(
+    private dialog: MatDialog,
+  ) { }
+
+  ngOnInit(): void {
+  }
+
+  openDeleteDialog(article: Article | ArticleWithAuthor) {
+    this.dialog.open(DeleteDialogComponent, {
+      autoFocus: false,
+      restoreFocus: false,
+      data: article,
+    });
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -6,10 +6,13 @@ import { ArticleComponent } from './article/article.component';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule } from '@angular/material/dialog';
 import { DeleteDialogComponent } from './delete-dialog/delete-dialog.component';
+import { NoteEditButtonsComponent } from './note-edit-buttons/note-edit-buttons.component';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
 
 @NgModule({
-  declarations: [ArticleComponent, DeleteDialogComponent],
-  imports: [CommonModule, SharedRoutingModule, MatButtonModule, MatDialogModule],
-  exports: [ArticleComponent, DeleteDialogComponent],
+  declarations: [ArticleComponent, DeleteDialogComponent, NoteEditButtonsComponent],
+  imports: [CommonModule, SharedRoutingModule, MatButtonModule, MatDialogModule, MatMenuModule, MatIconModule],
+  exports: [ArticleComponent, DeleteDialogComponent, NoteEditButtonsComponent],
 })
 export class SharedModule { }


### PR DESCRIPTION
fix #30 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ

![settings](https://user-images.githubusercontent.com/37304826/88468949-00f53c00-cf26-11ea-8606-e5aafd613d49.gif)

## 作業概要

### ログイン
- 初回ログイン時にTwitterのデータを追加、onCreateによって上書きされていたので修正
- 毎ログイン時にスクリーンネームを更新、OmitをPickに書き換え

### 設定
- settingsModule, Componentを作成
- ngx-image-cropperの導入、プロフィール画像の変更を実装、スタイル調整
- プロフィール画像の変更をimage-crop-dialogComponent内で実装
- プロフィールの更新処理を実装
- 退会処理を実装
- 退会後に記事が消えなかったのを修正
- 本人であればマイページに設定ページへの編集ボタンを表示

### 記事編集
- 記事編集削除ボタンをSharedに、記事詳細で実装

### Algolia
- オートコンプリート選択で結果表示、非公開記事が検索できたのを修正

### その他
- 記事詳細とマイページ画面でNotFoundになった場合の表示を修正
- エラ〜メッセージをコンソールに表示
- べき等関数の作成