### PR TITLE
タグを実装 #43

### DIFF
--- a/functions/src/interfaces/article.ts
+++ b/functions/src/interfaces/article.ts
@@ -5,7 +5,7 @@ export interface Article {
   uid: string;
   thumbnailURL: string;
   title: string;
-  tag: string;
+  tags: string[];
   text: string;
   isPublic: boolean;
   createdAt: firestore.Timestamp;

--- a/src/app/mypage/mypage.module.ts
+++ b/src/app/mypage/mypage.module.ts
@@ -10,6 +10,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { SharedModule } from '../shared/shared.module';
 import { MatTabsModule } from '@angular/material/tabs';
 import { FroalaViewModule } from 'angular-froala-wysiwyg';
+import { MatChipsModule } from '@angular/material/chips';
 
 @NgModule({
   declarations: [MypageComponent, NoteComponent],
@@ -22,6 +23,7 @@ import { FroalaViewModule } from 'angular-froala-wysiwyg';
     SharedModule,
     MatTabsModule,
     FroalaViewModule,
+    MatChipsModule
   ],
 })
 export class MypageModule { }

--- a/src/app/mypage/note/note.component.html
+++ b/src/app/mypage/note/note.component.html
@@ -44,8 +44,13 @@
         </div>
         <h1 class="note-header__title">{{article.title}}
         </h1>
-        <a href="#" class="note-header__tag">DTM</a>
-        <a href="#" class="note-header__tag">Sylenth1</a>
+        <ng-container *ngIf="article.tags">
+          <mat-chip-list aria-label="記事のタグ">
+            <mat-chip *ngFor="let tag of article.tags">
+              {{tag}}
+            </mat-chip>
+          </mat-chip-list>
+        </ng-container>
       </div>
       <div class="note-content" [froalaView]="article.text">
       </div>

--- a/src/app/mypage/note/note.component.scss
+++ b/src/app/mypage/note/note.component.scss
@@ -97,13 +97,6 @@
   &__title {
     padding: 0 4px;
   }
-  &__tag {
-    background-color: #eee;
-    padding: 8px;
-    color: #5e5d5d;
-    margin: 0 4px;
-    border-radius: 4px;
-  }
 }
 
 .note-content {

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -13,10 +13,15 @@
             {{tag}}
             <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
           </mat-chip>
-          <input placeholder="タグ" matInput autocomplete="off" [matChipInputFor]="chipList"
+          <input placeholder="タグ" matInput [matAutocomplete]="auto" [matChipInputFor]="chipList"
             [matChipInputSeparatorKeyCodes]="separatorKeysCodes" [matChipInputAddOnBlur]="addOnBlur"
-            (matChipInputTokenEnd)="add($event)" />
+            (matChipInputTokenEnd)="add($event)" #tagInput [formControl]="tagControl" />
         </mat-chip-list>
+        <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">
+          <mat-option *ngFor="let tag of tags" [value]="tag.value">
+            {{tag.value}}
+          </mat-option>
+        </mat-autocomplete>
         <mat-error *ngIf="tagsControl.hasError('maxlength')">タグは10個以内です</mat-error>
       </mat-form-field>
     </div>

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -1,15 +1,23 @@
 <div class="editor">
   <form class="editor__form" [formGroup]="form">
     <div class="editor__header">
-      <mat-form-field class="editor__title" floatLabel="always">
-        <mat-label></mat-label>
+      <mat-form-field class="editor__title">
         <input type="text" formControlName="title" matInput placeholder="タイトル*" autocomplete="off" />
         <mat-error *ngIf="titleControl.hasError('required')">必須項目です</mat-error>
-        <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは255文字以内にしてください</mat-error>
+        <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは255文字以内です</mat-error>
       </mat-form-field>
-      <mat-form-field class="editor__tag" floatLabel="always">
-        <mat-label></mat-label>
-        <input type="text" formControlName="tag" matInput placeholder="タグ" autocomplete="off" />
+      <mat-form-field class="editor__tags">
+        <mat-chip-list #chipList aria-label="タグセレクション" formControlName="tags">
+          <mat-chip *ngFor="let tag of form.get('tags').value" [selectable]="selectable" [removable]="removable"
+            (removed)="remove(tag)">
+            {{tag}}
+            <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
+          </mat-chip>
+          <input placeholder="タグ" matInput autocomplete="off" [matChipInputFor]="chipList"
+            [matChipInputSeparatorKeyCodes]="separatorKeysCodes" [matChipInputAddOnBlur]="addOnBlur"
+            (matChipInputTokenEnd)="add($event)" />
+        </mat-chip-list>
+        <mat-error *ngIf="tagsControl.hasError('maxlength')">タグは10個以内です</mat-error>
       </mat-form-field>
     </div>
     <div class="editor__content">

--- a/src/app/notes/create/create.component.html
+++ b/src/app/notes/create/create.component.html
@@ -7,22 +7,21 @@
         <mat-error *ngIf="titleControl.hasError('maxlength')">タイトルは255文字以内です</mat-error>
       </mat-form-field>
       <mat-form-field class="editor__tags">
-        <mat-chip-list #chipList aria-label="タグセレクション" formControlName="tags">
-          <mat-chip *ngFor="let tag of form.get('tags').value" [selectable]="selectable" [removable]="removable"
-            (removed)="remove(tag)">
+        <mat-chip-list #chipList aria-label="タグセレクション">
+          <mat-chip *ngFor="let tag of tags" [selectable]="selectable" [removable]="removable" (removed)="remove(tag)">
             {{tag}}
             <mat-icon matChipRemove *ngIf="removable">cancel</mat-icon>
           </mat-chip>
-          <input placeholder="タグ" matInput [matAutocomplete]="auto" [matChipInputFor]="chipList"
-            [matChipInputSeparatorKeyCodes]="separatorKeysCodes" [matChipInputAddOnBlur]="addOnBlur"
-            (matChipInputTokenEnd)="add($event)" #tagInput [formControl]="tagControl" />
+          <input placeholder="タグ" #tagInput [formControl]="tagControl" [matAutocomplete]="auto"
+            [matChipInputFor]="chipList" [matChipInputSeparatorKeyCodes]="separatorKeysCodes"
+            [matChipInputAddOnBlur]="addOnBlur" (matChipInputTokenEnd)="add($event)">
         </mat-chip-list>
         <mat-autocomplete #auto="matAutocomplete" (optionSelected)="selected($event)">
-          <mat-option *ngFor="let tag of tags" [value]="tag.value">
+          <mat-option *ngFor="let tag of allTags" [value]="tag.value">
             {{tag.value}}
           </mat-option>
         </mat-autocomplete>
-        <mat-error *ngIf="tagsControl.hasError('maxlength')">タグは10個以内です</mat-error>
+        <mat-hint>タグは10個以内です</mat-hint>
       </mat-form-field>
     </div>
     <div class="editor__content">

--- a/src/app/notes/create/create.component.scss
+++ b/src/app/notes/create/create.component.scss
@@ -1,6 +1,6 @@
 .editor {
   max-width: 800px;
-  margin: -10px auto;
+  margin: 0 auto;
   &__form {
     width: 100%;
   }
@@ -13,11 +13,11 @@
     padding: 8px 0;
   }
   &__title {
-    width: 48%;
-    padding-right: 18px;
+    width: 100%;
+    padding-bottom: 8px;
   }
-  &__tag {
-    width: 48%;
+  &__tags {
+    width: 100%;
   }
   &__content {
     width: 100%;
@@ -46,16 +46,4 @@ button {
 
 .input-thumbnail {
   display: none;
-}
-
-@media screen and (max-width: 612px) {
-  .editor {
-    &__title {
-      width: 100%;
-      padding-right: 0;
-    }
-    &__tag {
-      width: 100%;
-    }
-  }
 }

--- a/src/app/notes/notes.module.ts
+++ b/src/app/notes/notes.module.ts
@@ -13,6 +13,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { SharedModule } from '../shared/shared.module';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 
 @NgModule({
   declarations: [NotesComponent, CreateComponent],
@@ -28,7 +29,8 @@ import { MatChipsModule } from '@angular/material/chips';
     MatSlideToggleModule,
     MatIconModule,
     SharedModule,
-    MatChipsModule
+    MatChipsModule,
+    MatAutocompleteModule
   ],
 })
 export class NotesModule { }

--- a/src/app/notes/notes.module.ts
+++ b/src/app/notes/notes.module.ts
@@ -12,6 +12,7 @@ import { FroalaEditorModule } from 'angular-froala-wysiwyg';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { SharedModule } from '../shared/shared.module';
+import { MatChipsModule } from '@angular/material/chips';
 
 @NgModule({
   declarations: [NotesComponent, CreateComponent],
@@ -27,6 +28,7 @@ import { SharedModule } from '../shared/shared.module';
     MatSlideToggleModule,
     MatIconModule,
     SharedModule,
+    MatChipsModule
   ],
 })
 export class NotesModule { }

--- a/src/app/search-input/search-input.component.html
+++ b/src/app/search-input/search-input.component.html
@@ -3,7 +3,7 @@
     [matAutocomplete]="search" class="search__input" />
   <mat-autocomplete #search="matAutocomplete">
     <mat-option *ngFor="let option of searchResult?.hits" [value]="option.title">
-      <div class="search__input-item" (click)="routeSearch(option.title)">{{option.title}}</div>
+      <div (click)="routeSearch(option.title)">{{option.title}}</div>
     </mat-option>
   </mat-autocomplete>
   <button mat-icon-button color="white" aria-label="検索アイコン" class="search__button">
@@ -22,7 +22,7 @@
     [matAutocomplete]="search" class="smart-search-box__input" />
   <mat-autocomplete #search="matAutocomplete">
     <mat-option *ngFor="let option of searchResult?.hits" [value]="option.title">
-      {{option.title}}
+      <div (click)="routeSearch(option.title)">{{option.title}}</div>
     </mat-option>
   </mat-autocomplete>
   <button mat-icon-button color="white" aria-label="検索アイコン" class="smart-search-box__button">

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { AngularFireAuth } from '@angular/fire/auth';
-import { auth, User } from 'firebase/app';
+import { User } from 'firebase/app';
 import { Observable, of } from 'rxjs';
 import { Router } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';


### PR DESCRIPTION
fix #43 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ

![画面収録 2020-07-31 3 02 35 mov](https://user-images.githubusercontent.com/37304826/88957824-7b351000-d2da-11ea-86b2-a8f162b1dd4a.gif)

## 作業概要

- 記事作成画面タグ入力と詳細画面のタグ表示を実装、スタイル調整
- 検索時にスマホ時もオートコンプリートクリックで検索結果に遷移するように実装
- 記事作成画面のタグにオートコンプリートを実装
- tagの入力方法をformControlからmat-chipの配列に変更